### PR TITLE
Fix global variable usage in popup

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -152,7 +152,7 @@ function checkLoginSuccess(tabId, faviconColor) {
           tabs.forEach((tab) => {
             const tabUrl = new URL(tab.url);
             if (tabUrl.origin === url.origin) {
-              color = hexToRgb(faviconColor);
+              const color = hexToRgb(faviconColor);
               changeFavicon(tab.id, color);
             }
           });


### PR DESCRIPTION
## Summary
- remove implicit global `color` variable in `checkLoginSuccess`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d21bed8cc83209e87b23c03cd048a