### PR TITLE
Fix new tab login listener

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -128,11 +128,11 @@ const loginToSalesforce = async (credential, loginType) => {
   } 
   // 12. Handle login in a new tab.
   else if (loginType === "newTab") {
-    const tab = await chrome.tabs.create({
+    chrome.tabs.onCreated.addListener(removableListener);
+    await chrome.tabs.create({
       url: salesforceURL,
       active: true,
     });
-    setOnCreatedListener(tab.id, credential);
   }
 };
 


### PR DESCRIPTION
## Summary
- register the tab creation listener before creating a new tab
- let `removableListener` handle injecting credentials

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d2830775c8320bea50eca259fa1db