### PR TITLE
Fix new tab login

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -128,11 +128,15 @@ const loginToSalesforce = async (credential, loginType) => {
   } 
   // 12. Handle login in a new tab.
   else if (loginType === "newTab") {
-    chrome.tabs.onCreated.addListener(removableListener);
-    await chrome.tabs.create({
+    const tab = await chrome.tabs.create({
       url: salesforceURL,
       active: true,
     });
+    if (tab && tab.id) {
+      await setOnCreatedListener(tab.id, credential);
+    } else {
+      console.error("Failed to create tab for newTab login.");
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- ensure login script runs when opened in a new tab

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d2a2488388320b210662654f20941