### PR TITLE
Complete 2FA authenticator, hover-to-copy, OS-aware biometric unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ A companion Node CLI (`sffav`) manages your logins from the terminal and — unl
 extension's `localStorage` — keeps them in an **encrypted vault**, never plaintext.
 
 ```bash
-npm link          # exposes `sffav` (or use: npm run cli -- <args>)
+npm link          # exposes `sffav` for development (or: npm run cli -- <args>)
+# or install it globally from the repo:  npm i -g .
 
 sffav init                                   # create an encrypted vault (prompts for a passphrase)
 sffav add --name "Acme Prod" --env production --username me@acme.com --password '…' --totp BASE32KEY
@@ -172,6 +173,13 @@ sffav totp "Acme Prod" --uri          # print the otpauth:// URI (turn into a QR
 sffav totp "Acme Prod"                # the current 6-digit code + seconds left
 sffav totp "Acme Prod" --raw          # just the 6 digits (for scripts/agents)
 ```
+
+These are real RFC-6238 TOTP codes (SHA-1, 6 digits, 30s), the same algorithm authenticator
+apps use — so `sffav totp … --raw` and Google Authenticator print the **same code** for the
+same key. `tests/cli.test.js` proves this end-to-end: it drives the CLI against a throwaway
+vault and asserts its output matches the unit-tested library, and that the key is stored
+encrypted (never in the vault file as plaintext). The extension popup shows the same live
+code on each org card, and can auto-fill it on Salesforce's login challenge.
 
 ### Agents / CI (non-interactive)
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,23 @@ vault and asserts its output matches the unit-tested library, and that the key i
 encrypted (never in the vault file as plaintext). The extension popup shows the same live
 code on each org card, and can auto-fill it on Salesforce's login challenge.
 
+### The extension's built-in authenticator requires this CLI
+
+By design, the in-popup 2FA authenticator (the key field + QR + live code on each card) is
+available **only when the `sffav` CLI is installed** — the CLI is the encrypted, testable
+source of truth for authenticator keys. A browser extension can't see a globally-installed
+binary directly, so the CLI registers a tiny **native-messaging host** that the popup pings:
+
+```bash
+npm i -g .                                   # install the CLI
+sffav install-host                           # register the native host (published build)
+sffav install-host <your-extension-id>       # …or pass your unpacked/dev id (chrome://extensions)
+```
+
+Reopen the popup and the built-in authenticator appears; without it, the popup shows an
+"install the CLI" hint instead. `sffav uninstall-host` removes the registration.
+`tests/native-host.test.js` covers the host handshake and the manifest it writes.
+
 ### Agents / CI (non-interactive)
 
 An automated agent can pull a live MFA code without any prompt — set the passphrase in

--- a/background.js
+++ b/background.js
@@ -15,22 +15,74 @@
 importScripts("popup/credentials.js"); // exposes self.SFFav (pure helpers)
 
 // ── function injected into the PAGE (self-contained: no chrome.*, no SW scope) ──
+// Some orgs have "Login Discovery" enabled on My Domain: the first page only
+// asks for the username, and the password field only appears on a SEPARATE
+// page after submitting it (a real navigation, which tears down this
+// function's execution — it can't just "wait" through that from in here).
+// So this fills+submits whatever step is present and reports back which case
+// it hit; the caller (handleLogin) is responsible for waiting for the
+// follow-up page and injecting fillSalesforcePasswordStep there.
 async function fillSalesforceLogin(username, password) {
   try {
-    // Give the login form a beat to finish wiring up after load.
-    await new Promise((r) => setTimeout(r, 400));
-    const userField = document.getElementById("username");
-    const passField = document.getElementById("password");
-    const loginButton = document.querySelector("#Login");
-    if (!userField || !passField) {
-      console.error("SalesForceFav: username/password fields not found on this page.");
-      return;
+    // Poll for the field for a couple seconds instead of a single fixed wait —
+    // a redirect chain (e.g. a geo/POD bounce) can leave the real login page
+    // still settling after the tab's "complete" event fires.
+    let userField = null;
+    for (let i = 0; i < 25; i += 1) {
+      userField = document.getElementById("username");
+      if (userField) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    if (!userField) {
+      console.error("SalesForceFav: username field not found on this page.");
+      return "no-username-field";
     }
     userField.value = username;
-    passField.value = password;
-    if (loginButton) loginButton.click();
+    userField.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const passField = document.getElementById("password");
+    const submitButton = document.querySelector("#Login");
+    if (passField) {
+      // Standard single-page login — fill both and submit now.
+      passField.value = password;
+      if (submitButton) submitButton.click();
+      return "filled";
+    }
+    // Login Discovery — no password field yet. Submit the username step; the
+    // password step happens on whatever page this navigates to.
+    if (submitButton) {
+      submitButton.click();
+      return "needs-password-step";
+    }
+    console.error("SalesForceFav: no password field and no submit button found.");
+    return "stuck";
   } catch (e) {
     console.error("SalesForceFav: login fill failed:", e);
+    return "error";
+  }
+}
+
+// Fills the password step of a Login Discovery flow, on the page reached
+// after fillSalesforceLogin submitted the username. Same polling approach —
+// this page can still be settling right after "complete" fires.
+async function fillSalesforcePasswordStep(password) {
+  try {
+    let passField = null;
+    for (let i = 0; i < 10; i += 1) {
+      passField = document.getElementById("password");
+      if (passField) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    if (!passField) {
+      console.error("SalesForceFav: password field not found on the follow-up page.");
+      return;
+    }
+    passField.value = password;
+    passField.dispatchEvent(new Event("input", { bubbles: true }));
+    const submitButton = document.querySelector("#Login");
+    if (submitButton) submitButton.click();
+  } catch (e) {
+    console.error("SalesForceFav: password step fill failed:", e);
   }
 }
 
@@ -71,11 +123,44 @@ function tintFaviconInPage(color) {
   }
 }
 
+// Paint the org's color INSIDE the page: a slim stripe across the very top of
+// the viewport, plus a matching accent on the SLDS global header when present
+// (Lightning). Page context, idempotent — safe to re-run on every navigation.
+function tintOrgHeaderInPage(colorHex) {
+  try {
+    let stripe = document.getElementById("sffav-org-stripe");
+    if (!stripe) {
+      stripe = document.createElement("div");
+      stripe.id = "sffav-org-stripe";
+      stripe.style.cssText =
+        "position:fixed;top:0;left:0;right:0;height:3px;z-index:2147483647;pointer-events:none;";
+      document.documentElement.appendChild(stripe);
+    }
+    stripe.style.background = colorHex;
+
+    let style = document.getElementById("sffav-org-style");
+    if (!style) {
+      style = document.createElement("style");
+      style.id = "sffav-org-style";
+      document.documentElement.appendChild(style);
+    }
+    // inset box-shadow rather than border so the Lightning header's height
+    // (which its own JS measures) is unchanged.
+    style.textContent =
+      `.slds-global-header{box-shadow:inset 0 3px 0 ${colorHex} !important;}` +
+      `.slds-global-header__logo{filter:drop-shadow(0 2px 0 ${colorHex});}`;
+  } catch (e) {
+    console.error("SalesForceFav: header tint failed:", e);
+  }
+}
+
 // Fill a one-time-code field on the Salesforce verification page (page context).
-// SAFETY: fills but NEVER submits — a TOTP can roll over between compute and
-// submit, and repeated bad MFA attempts lock accounts. The user confirms. Strictly
-// no-op when no verification field is present (most logins won't show one).
-function fillTotpCodeInPage(code) {
+// Fills only by default; clicks the verify/submit control when `submit` is true.
+// Auto-submit is gated by the caller (handleLogin) on the code's remaining
+// validity — a TOTP can roll over between compute and submit, and repeated bad
+// MFA attempts lock accounts. Strictly no-op when no verification field is
+// present (most logins won't show one).
+function fillTotpCodeInPage(code, submit) {
   try {
     const selectors = [
       'input[autocomplete="one-time-code"]', // standard MFA code attribute
@@ -95,11 +180,261 @@ function fillTotpCodeInPage(code) {
     if (!field) return; // not a verification page — do nothing
     field.value = code;
     field.dispatchEvent(new Event("input", { bubbles: true }));
-    // Intentionally NOT clicking submit — the human commits the code.
+    if (!submit) return; // fill-only (default) — the human commits the code
+    // Auto-submit: click the verify/submit control if one is present. The
+    // caller only sets submit=true after guarding the code's remaining validity
+    // (see handleLogin), so the code it just typed has a full window to land.
+    const submitBtn =
+      document.querySelector("#save") ||
+      document.querySelector('input[type="submit"]') ||
+      document.querySelector('button[type="submit"]');
+    if (submitBtn) submitBtn.click();
   } catch (e) {
     console.error("SalesForceFav: 2FA code fill failed:", e);
   }
 }
+
+// Offer to set up 2FA on the post-login page, for orgs that don't have an
+// authenticator key saved yet (page context; relies on the vendored QR
+// encoder being injected as a file just before this function). The secret is
+// generated up front but only reported back to the extension — via
+// chrome.runtime.sendMessage, which content-script-world code can call even
+// though this function itself never touches chrome.storage — once the user
+// confirms they've scanned it. Labeled "SalesForceFav" (the otpauth issuer)
+// so it's identifiable in whatever authenticator app scans it.
+function showTotpSetupPrompt(credentialName, secret, otpauthUri) {
+  try {
+    if (document.getElementById("sffav-totp-prompt")) return; // already showing
+    const card = document.createElement("div");
+    card.id = "sffav-totp-prompt";
+    card.style.cssText =
+      "position:fixed;bottom:16px;right:16px;z-index:2147483647;width:300px;" +
+      "background:#fff;color:#1a1a1a;border:1px solid #d9d9d9;border-radius:10px;" +
+      "box-shadow:0 8px 24px rgba(0,0,0,.2);padding:14px;" +
+      "font:13px/1.4 -apple-system,BlinkMacSystemFont,sans-serif;";
+
+    // Branded header — an unmarked floating card on an identity-verification
+    // page reads as suspicious rather than trustworthy, so this is explicit
+    // about which extension put it there (plain inline SVG, not an <img> tag,
+    // since chrome-extension:// image URLs need web_accessible_resources to
+    // load from a page context — inline markup needs no such declaration).
+    const header = document.createElement("div");
+    header.style.cssText = "display:flex;align-items:center;gap:8px;margin-bottom:8px;";
+    header.innerHTML =
+      '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="#3a5ccc" ' +
+      'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+      '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>' +
+      '<strong style="font-size:13px;">SalesForceFav</strong>';
+    card.appendChild(header);
+
+    const title = document.createElement("div");
+    title.style.cssText = "font-weight:600;margin-bottom:6px;";
+    title.textContent = "Set up 2FA for this org?";
+    card.appendChild(title);
+
+    const body = document.createElement("div");
+    body.id = "sffav-totp-body";
+    card.appendChild(body);
+    document.body.appendChild(card);
+
+    const showOffer = () => {
+      body.textContent = "";
+      const hint = document.createElement("p");
+      hint.style.cssText = "margin:0 0 10px;color:#555;";
+      hint.textContent = "SalesForceFav (this extension) can be this org's authenticator.";
+      const yes = document.createElement("button");
+      yes.textContent = "Set up";
+      yes.style.marginRight = "8px";
+      const no = document.createElement("button");
+      no.textContent = "Not now";
+      no.addEventListener("click", () => card.remove());
+      yes.addEventListener("click", showQr);
+      body.appendChild(hint);
+      body.appendChild(yes);
+      body.appendChild(no);
+    };
+
+    // Renders the QR at `cellSize` into `qrHost` — factored out so the "view
+    // larger" toggle can re-render bigger without duplicating the QR setup.
+    const renderQr = (qrHost, cellSize) => {
+      qrHost.innerHTML = "";
+      try {
+        const qr = qrcode(0, "Q"); // type 0 = auto-size, error-correction level Q (tolerates screen glare)
+        qr.addData(otpauthUri);
+        qr.make();
+        qrHost.innerHTML = qr.createSvgTag({ cellSize, margin: 2, scalable: true });
+      } catch (e) {
+        qrHost.textContent = "QR render failed — use the key below.";
+      }
+    };
+
+    const showQr = () => {
+      body.textContent = "";
+      const hint = document.createElement("p");
+      hint.style.cssText = "margin:0 0 8px;color:#555;";
+      hint.textContent =
+        'In Setup → Advanced User Details, use "App Registration: Authenticator Apps" ' +
+        '(not "Built-In Authenticators" — that\'s for device biometrics/security keys) ' +
+        "and scan this, or paste the key manually.";
+      body.appendChild(hint);
+
+      const qrHost = document.createElement("div");
+      qrHost.style.cssText =
+        "background:#fff;padding:6px;border-radius:6px;width:150px;margin:0 auto;cursor:zoom-in;";
+      qrHost.title = "Click to enlarge";
+      let enlarged = false;
+      qrHost.addEventListener("click", () => {
+        enlarged = !enlarged;
+        qrHost.style.width = enlarged ? "260px" : "150px";
+        qrHost.style.cursor = enlarged ? "zoom-out" : "zoom-in";
+        renderQr(qrHost, enlarged ? 8 : 5);
+      });
+      renderQr(qrHost, 5);
+      body.appendChild(qrHost);
+
+      const key = document.createElement("code");
+      key.textContent = secret.replace(/(.{4})/g, "$1 ").trim();
+      key.style.cssText =
+        "display:block;margin:8px 0;text-align:center;font-weight:600;word-break:break-all;";
+      body.appendChild(key);
+
+      // The tradeoff of this whole feature, stated once, where the decision
+      // actually happens — not just something explained in a chat that goes
+      // away: the key lives next to the saved password, so a compromised
+      // browser exposes both factors together. Fine for disposable dev/test
+      // orgs; skip it for a production admin account.
+      const caveat = document.createElement("p");
+      caveat.style.cssText = "margin:8px 0 0;color:#8a6d00;font-size:11px;line-height:1.4;";
+      caveat.textContent =
+        "Note: this stores the 2FA key next to the saved password in the extension — " +
+        "convenient for dev/test orgs, but means a compromised browser exposes both. " +
+        "Skip this for production admin accounts.";
+      body.appendChild(caveat);
+
+      const save = document.createElement("button");
+      save.textContent = "I've scanned it — save";
+      save.style.marginRight = "8px";
+      save.style.marginTop = "8px";
+      const cancel = document.createElement("button");
+      cancel.textContent = "Cancel";
+      cancel.style.marginTop = "8px";
+      cancel.addEventListener("click", () => card.remove());
+      save.addEventListener("click", () => {
+        chrome.runtime.sendMessage({ type: "sffav-save-totp", credentialName, secret });
+        card.remove();
+      });
+      body.appendChild(save);
+      body.appendChild(cancel);
+    };
+
+    showOffer();
+  } catch (e) {
+    console.error("SalesForceFav: 2FA setup prompt failed:", e);
+  }
+}
+
+// Storage key for authenticator keys generated by showTotpSetupPrompt but not
+// yet written to a credential. The service worker has no localStorage (where
+// the popup keeps its — possibly encrypted — vault) and no passphrase, so it
+// can't persist the key itself; it stages it here, and the popup adopts it
+// into the matching credential (and re-encrypts, if applicable) next time it
+// opens. See applyPendingTotp() in popup.js.
+const PENDING_TOTP_KEY = "sffav-pending-totp";
+
+async function stagePendingTotp(credentialName, secret) {
+  const stored = await chrome.storage.local.get(PENDING_TOTP_KEY);
+  const pending = Array.isArray(stored[PENDING_TOTP_KEY]) ? stored[PENDING_TOTP_KEY] : [];
+  pending.push({ credentialName, secret });
+  await chrome.storage.local.set({ [PENDING_TOTP_KEY]: pending });
+}
+
+// ── org color following the tab ──────────────────────────────────────────────
+// tabId → faviconColor for tabs opened by a login. Kept in chrome.storage.session
+// (not a module variable) because MV3 service workers restart constantly, and in
+// session (not local) storage so stale tab ids don't accumulate across browser
+// restarts. The onUpdated listener below re-applies the favicon + header tint on
+// EVERY completed navigation in a tracked tab — a login-time one-shot injection
+// would be wiped by the first post-login redirect.
+const TAB_COLORS_KEY = "sffav-tab-colors";
+
+async function getTabColors() {
+  try {
+    const stored = await chrome.storage.session.get(TAB_COLORS_KEY);
+    return stored[TAB_COLORS_KEY] || {};
+  } catch {
+    return {};
+  }
+}
+
+// Best-effort: the org tint is cosmetic, so a storage.session hiccup here must
+// never propagate and abort the login fill that follows it in handleLogin.
+async function rememberTabColor(tabId, color) {
+  try {
+    const map = await getTabColors();
+    map[String(tabId)] = color;
+    await chrome.storage.session.set({ [TAB_COLORS_KEY]: map });
+  } catch (e) {
+    console.error("SalesForceFav: could not remember tab color (non-fatal):", e);
+  }
+}
+
+// Only tint Salesforce-owned hosts — the user can navigate a tracked tab
+// anywhere, and the org color shouldn't follow them onto unrelated sites.
+function isSalesforceHost(url) {
+  try {
+    const host = new URL(url).hostname;
+    return [
+      ".salesforce.com",
+      ".force.com",
+      ".cloudforce.com",
+      ".visualforce.com",
+      ".salesforce-setup.com",
+    ].some((suffix) => host.endsWith(suffix));
+  } catch {
+    return false;
+  }
+}
+
+// Injection can lose a race with the page itself: "complete" fires, the page
+// immediately redirects (login flows chain redirects), and by the time
+// executeScript reaches the tab its frame is gone. That's expected — the next
+// navigation's own "complete" event re-applies the tint — so those errors are
+// swallowed rather than logged as failures.
+function isGoneError(e) {
+  const msg = String((e && e.message) || e);
+  return /frame with id|no tab with id|tab was closed|cannot access/i.test(msg);
+}
+
+async function applyTabColor(tabId, color) {
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      func: tintFaviconInPage,
+      args: [self.SFFav.hexToRgb(color)],
+    });
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      func: tintOrgHeaderInPage,
+      args: [color],
+    });
+  } catch (e) {
+    if (!isGoneError(e)) console.error("SalesForceFav: tab tint failed:", e);
+  }
+}
+
+chrome.tabs.onUpdated.addListener(async (tabId, info, tab) => {
+  if (info.status !== "complete" || !tab || !isSalesforceHost(tab.url)) return;
+  const map = await getTabColors();
+  const color = map[String(tabId)];
+  if (color) await applyTabColor(tabId, color);
+});
+
+chrome.tabs.onRemoved.addListener(async (tabId) => {
+  const map = await getTabColors();
+  if (map[String(tabId)] === undefined) return;
+  delete map[String(tabId)];
+  await chrome.storage.session.set({ [TAB_COLORS_KEY]: map });
+});
 
 // ── orchestration (service worker context) ──────────────────────────────────
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
@@ -111,6 +446,24 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         sendResponse({ ok: false });
       });
     return true; // keep the message channel (and worker) alive for the async work
+  }
+  if (msg && msg.type === "sffav-save-totp" && msg.credentialName && msg.secret) {
+    stagePendingTotp(msg.credentialName, msg.secret)
+      .then(() => sendResponse({ ok: true }))
+      .catch((e) => {
+        console.error("SalesForceFav: staging 2FA key failed:", e);
+        sendResponse({ ok: false });
+      });
+    return true;
+  }
+  if (msg && msg.type === "sffav-setup-totp" && msg.credential) {
+    handleTotpSetup(msg.credential)
+      .then(() => sendResponse({ ok: true }))
+      .catch((e) => {
+        console.error("SalesForceFav: 2FA setup flow failed:", e);
+        sendResponse({ ok: false });
+      });
+    return true;
   }
   return false;
 });
@@ -125,10 +478,37 @@ async function handleLogin(credential, loginType) {
   // Salesforce username/password filler doesn't apply to the IdP page.
   const shouldFill = credential.environment !== "sso";
 
+  if (loginType === "incognito") {
+    // Without this permission, chrome.windows.create({incognito: true}) still
+    // creates the window, but its `tabs` come back empty/undefined (the
+    // extension isn't allowed to see into it) — which otherwise surfaces as
+    // an unhelpful "no tab was created" with no clue why. Check and explain
+    // it up front instead.
+    const allowed = await chrome.extension.isAllowedIncognitoAccess();
+    if (!allowed) {
+      console.error(
+        'SalesForceFav: incognito login needs "Allow in incognito" enabled for this ' +
+          "extension — go to chrome://extensions, open SalesForceFav's Details, and turn it on."
+      );
+      return;
+    }
+  }
+
   let tab;
   if (loginType === "newWindow" || loginType === "incognito") {
     const win = await chrome.windows.create({ url, incognito: loginType === "incognito" });
     tab = win && Array.isArray(win.tabs) ? win.tabs[0] : null;
+    // The tab object returned inline by windows.create can be a placeholder
+    // whose id/url don't yet match the real loading tab — re-resolve by
+    // querying the new window's active tab, which is authoritative.
+    if (win && win.id != null) {
+      try {
+        const [active] = await chrome.tabs.query({ windowId: win.id, active: true });
+        if (active && active.id != null) tab = active;
+      } catch (e) {
+        console.error("SalesForceFav: could not query the new window's tab:", e);
+      }
+    }
   } else {
     tab = await chrome.tabs.create({ url, active: true });
   }
@@ -136,47 +516,155 @@ async function handleLogin(credential, loginType) {
     console.error("SalesForceFav: no tab was created for the login.");
     return;
   }
+  console.log(`SalesForceFav: login (${loginType}) using tab ${tab.id}`);
+
+  // Register the org color for this tab FIRST — the onUpdated listener then
+  // re-applies the favicon + header tint on every navigation (login page,
+  // post-login redirect, Lightning), not just once.
+  if (credential.faviconColor) {
+    await rememberTabColor(tab.id, credential.faviconColor);
+  }
+
   if (!shouldFill) return;
 
   await waitForTabComplete(tab.id);
-  await chrome.scripting.executeScript({
+  let [fillResult] = await chrome.scripting.executeScript({
     target: { tabId: tab.id },
     func: fillSalesforceLogin,
     args: [credential.username, credential.password],
   });
-
-  // Tint the tab's favicon to the credential color so the logged-in tab is
-  // visually distinct (best-effort; runs in the page).
-  if (credential.faviconColor) {
+  // A fresh window (newWindow/incognito) spins up its own renderer and loads
+  // slower than a new tab in the current process — the login page can still be
+  // arriving when the first fill polls out. If the field wasn't found, wait for
+  // the next completed load and try once more before giving up.
+  if (fillResult && fillResult.result === "no-username-field") {
     try {
-      await chrome.scripting.executeScript({
+      await waitForTabComplete(tab.id);
+      [fillResult] = await chrome.scripting.executeScript({
         target: { tabId: tab.id },
-        func: tintFaviconInPage,
-        args: [self.SFFav.hexToRgb(credential.faviconColor)],
+        func: fillSalesforceLogin,
+        args: [credential.username, credential.password],
       });
     } catch (e) {
-      console.error("SalesForceFav: favicon tint failed:", e);
+      console.error("SalesForceFav: login fill retry failed:", e);
+    }
+  }
+  if (fillResult && fillResult.result === "needs-password-step") {
+    // Login Discovery org: the username step just submitted and navigated to
+    // a separate password step — wait for that page and fill it there.
+    try {
+      await waitForTabComplete(tab.id);
+      await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        func: fillSalesforcePasswordStep,
+        args: [credential.password],
+      });
+    } catch (e) {
+      console.error("SalesForceFav: password step failed:", e);
     }
   }
 
-  // If the org has an authenticator key, fill the 2FA code on the verification
-  // page that Salesforce shows after login (untrusted-device challenge). Filled,
-  // never submitted; no-op if the challenge doesn't appear. Best-effort against
-  // Salesforce's DOM — see the note in fillTotpCodeInPage.
+  // Immediate tint for the page that's already loaded (the onUpdated listener
+  // may have fired before rememberTabColor finished on the very first load).
+  if (credential.faviconColor) {
+    await applyTabColor(tab.id, credential.faviconColor);
+  }
+
+  // If the org has an authenticator key, fill AND submit the 2FA code on the
+  // verification page Salesforce shows after login (untrusted-device challenge).
+  // No-op if the challenge doesn't appear. Best-effort against Salesforce's DOM
+  // — see the note in fillTotpCodeInPage.
+  //
+  // Auto-submit tradeoff: repeated bad MFA codes lock accounts, so we never
+  // submit a code that's about to roll over. If under 5s remain in the current
+  // 30s window, wait for the next window first, then compute a fresh code — that
+  // way the code we submit has a near-full window to be accepted server-side.
   if (credential.totp && self.SFFav.isValidTotpSecret(credential.totp)) {
     try {
       await waitForNextComplete(tab.id, 10000); // the post-login navigation
+      const secondsLeft = self.SFFav.totpSecondsRemaining(Date.now() / 1000);
+      if (secondsLeft < 5) {
+        await new Promise((r) => setTimeout(r, (secondsLeft + 0.3) * 1000));
+      }
       const code = self.SFFav.totp(credential.totp, Date.now() / 1000);
       if (code) {
         await chrome.scripting.executeScript({
           target: { tabId: tab.id },
           func: fillTotpCodeInPage,
-          args: [code],
+          args: [code, true], // submit=true — guarded above
         });
       }
     } catch (e) {
       console.error("SalesForceFav: 2FA autofill step failed:", e);
     }
+  }
+  // No automatic prompt when the org has no key — 2FA setup is only offered
+  // when explicitly requested (see handleTotpSetup below), not on every login.
+}
+
+// Explicit, on-demand counterpart to the 2FA autofill above: opens the org,
+// logs in, and always shows the setup prompt (skipping the "already has a
+// key?" check, since the caller — the popup's "Set up 2FA" button — only
+// offers this for credentials that don't have one yet).
+async function handleTotpSetup(credential) {
+  const url = self.SFFav.resolveSalesforceUrl(credential);
+  if (!url) {
+    console.error("SalesForceFav: could not resolve a URL for this credential.");
+    return;
+  }
+  const shouldFill = credential.environment !== "sso";
+
+  const tab = await chrome.tabs.create({ url, active: true });
+  if (!tab || tab.id == null) {
+    console.error("SalesForceFav: no tab was created for 2FA setup.");
+    return;
+  }
+  if (credential.faviconColor) {
+    await rememberTabColor(tab.id, credential.faviconColor);
+  }
+
+  await waitForTabComplete(tab.id);
+  if (shouldFill) {
+    const [fillResult] = await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: fillSalesforceLogin,
+      args: [credential.username, credential.password],
+    });
+    if (fillResult && fillResult.result === "needs-password-step") {
+      // Login Discovery org — fill the password on the separate follow-up page.
+      try {
+        await waitForTabComplete(tab.id);
+        await chrome.scripting.executeScript({
+          target: { tabId: tab.id },
+          func: fillSalesforcePasswordStep,
+          args: [credential.password],
+        });
+      } catch (e) {
+        console.error("SalesForceFav: password step failed:", e);
+      }
+    }
+    await waitForNextComplete(tab.id, 10000); // the post-login navigation
+  }
+
+  try {
+    const bytes = new Uint8Array(20); // 160-bit secret (RFC 6238 §5.1)
+    crypto.getRandomValues(bytes);
+    const secret = self.SFFav.base32Encode(bytes);
+    const otpauthUri = self.SFFav.buildOtpauthUri({
+      account: credential.username || credential.credentialName || "account",
+      secret,
+    });
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      files: ["popup/vendor/qrcode.js"],
+    });
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: showTotpSetupPrompt,
+      args: [credential.credentialName, secret, otpauthUri],
+    });
+  } catch (e) {
+    console.error("SalesForceFav: 2FA setup prompt failed:", e);
   }
 }
 
@@ -199,26 +687,55 @@ function waitForNextComplete(tabId, timeoutMs) {
   });
 }
 
-// Resolve once the tab has finished loading. Handles the case where it already
-// completed before we started listening (fast/cached loads).
+// Resolve once the tab has finished loading AND settled on its final URL.
+// A freshly created tab can report "complete" for its transient about:blank
+// frame before the real navigation even starts, and Salesforce's login flow
+// can bounce through a client-side redirect (e.g. test.salesforce.com →
+// login.salesforce.com) that fires its OWN "complete" on the intermediate
+// page before navigating again — either case would make a naive "wait for
+// one complete event" resolve too early and run the fill script against a
+// page with no login form yet. So after each "complete", this waits a short
+// grace period and re-checks: if the URL is still changing, it waits for the
+// next "complete" too, instead of assuming the first one was the real page.
 function waitForTabComplete(tabId) {
+  const isRealPage = (url) => !!url && url !== "about:blank" && !url.startsWith("chrome://");
   return new Promise((resolve) => {
-    chrome.tabs.get(tabId, (tab) => {
-      if (chrome.runtime.lastError) {
-        resolve();
-        return;
-      }
-      if (tab && tab.status === "complete") {
-        resolve();
-        return;
-      }
-      const listener = (updatedId, info) => {
-        if (updatedId === tabId && info.status === "complete") {
-          chrome.tabs.onUpdated.removeListener(listener);
+    const waitForNextCompleteEvent = () => {
+      chrome.tabs.get(tabId, (tab) => {
+        if (chrome.runtime.lastError) {
           resolve();
+          return;
         }
-      };
-      chrome.tabs.onUpdated.addListener(listener);
-    });
+        if (tab && tab.status === "complete" && isRealPage(tab.url)) {
+          settle(tab.url);
+          return;
+        }
+        const listener = (updatedId, info, updatedTab) => {
+          if (updatedId === tabId && info.status === "complete" && isRealPage(updatedTab.url)) {
+            chrome.tabs.onUpdated.removeListener(listener);
+            settle(updatedTab.url);
+          }
+        };
+        chrome.tabs.onUpdated.addListener(listener);
+      });
+    };
+    // Confirms the tab is still on `urlAtComplete` after a beat — if it moved
+    // on since, a redirect is still in flight, so wait for the next completion.
+    const settle = (urlAtComplete) => {
+      setTimeout(() => {
+        chrome.tabs.get(tabId, (tab) => {
+          if (chrome.runtime.lastError || !tab) {
+            resolve();
+            return;
+          }
+          if (tab.status === "complete" && tab.url === urlAtComplete) {
+            resolve();
+          } else {
+            waitForNextCompleteEvent();
+          }
+        });
+      }, 500);
+    };
+    waitForNextCompleteEvent();
   });
 }

--- a/cli/native-host.cjs
+++ b/cli/native-host.cjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+"use strict";
+
+// SalesForceFav native-messaging host.
+//
+// Its ONLY job is to exist and answer a ping, so the extension popup can prove
+// the sffav CLI is installed on this machine (chrome.runtime.sendNativeMessage).
+// That gates the in-popup "built-in authenticator" — see popup.js probeCli().
+//
+// It exposes NO vault data and needs no passphrase: presence is the whole
+// signal. Registered by `sffav install-host` (see sffav.cjs), which writes the
+// host manifest that points Chrome/Edge at this file.
+//
+// Wire format (Chrome native messaging): each message is a 4-byte little-endian
+// length prefix followed by that many bytes of UTF-8 JSON, both directions.
+
+const HOST_NAME = "com.salesforcefav.host";
+
+let version = "unknown";
+try {
+  version = require("../package.json").version || version;
+} catch {
+  /* package.json not resolvable when run oddly — presence still answers */
+}
+
+function send(obj) {
+  const body = Buffer.from(JSON.stringify(obj), "utf8");
+  const header = Buffer.alloc(4);
+  header.writeUInt32LE(body.length, 0);
+  process.stdout.write(Buffer.concat([header, body]));
+}
+
+let buffer = Buffer.alloc(0);
+process.stdin.on("data", (chunk) => {
+  buffer = Buffer.concat([buffer, chunk]);
+  // Drain every complete frame currently buffered.
+  while (buffer.length >= 4) {
+    const len = buffer.readUInt32LE(0);
+    if (buffer.length < 4 + len) break; // wait for the rest of this frame
+    const body = buffer.subarray(4, 4 + len);
+    buffer = buffer.subarray(4 + len);
+    let req = {};
+    try {
+      req = JSON.parse(body.toString("utf8"));
+    } catch {
+      /* malformed — still answer so the caller learns we're here */
+    }
+    send({
+      ok: true,
+      host: HOST_NAME,
+      app: "SalesForceFav",
+      version,
+      echo: (req && req.type) || null,
+    });
+  }
+});
+
+// Chrome closes stdin after a sendNativeMessage round-trip; exit cleanly then.
+process.stdin.on("end", () => process.exit(0));

--- a/cli/sffav.cjs
+++ b/cli/sffav.cjs
@@ -10,6 +10,7 @@
 //
 //   sffav init                 create a new empty encrypted vault
 //   sffav add --name "Prod" --env production --username u --password p [--totp KEY] [--color #2563eb]
+//             --env custom needs --customurl https://acme.my.salesforce.com (My Domain login)
 //   sffav list                 list orgs (no secrets printed)
 //   sffav totp "Prod"          print the current 2FA code + seconds left
 //     --raw                    print only the 6 digits (for agents / scripts)
@@ -130,6 +131,7 @@ const commands = {
       credentialName: String(flags.name || "").trim(),
       environment: String(flags.env || "").trim(),
       ssourl: String(flags.ssourl || "").trim(),
+      customurl: String(flags.customurl || "").trim(),
       username: String(flags.username || "").trim(),
       password: typeof flags.password === "string" ? flags.password : "",
       totp: String(flags.totp || "").trim(),

--- a/cli/sffav.cjs
+++ b/cli/sffav.cjs
@@ -21,15 +21,82 @@
 //   sffav rm "Prod"            remove an org
 //   sffav export <file>        write a PLAINTEXT backup (extension-compatible) — warns
 //   sffav import <file>        merge a backup file into the vault
+//   sffav install-host [id…]   register the native host so the EXTENSION can detect
+//                              the CLI (gates its built-in authenticator). Pass your
+//                              unpacked extension id(s); the store id is included.
+//   sffav uninstall-host       remove the native-host registration
 //
 // Options: --vault <path> (default: ./sffav-vault.json or $SFFAV_VAULT)
 
 const fs = require("node:fs");
 const path = require("node:path");
+const os = require("node:os");
 const crypto = require("node:crypto");
+const { execFileSync } = require("node:child_process");
 const readline = require("node:readline");
 const SFFav = require("../popup/credentials.js");
 const { encryptVault, decryptVault } = require("./vault.cjs");
+
+// ── native-messaging host (extension "is the CLI installed?" detector) ─────────
+// The browser extension can't see a globally-installed binary, so `install-host`
+// registers a tiny native-messaging host (cli/native-host.cjs) that the popup
+// pings to prove the CLI is present — which gates the in-popup built-in
+// authenticator. See native-host.cjs and popup.js probeCli().
+const NM_HOST_NAME = "com.salesforcefav.host";
+// SalesForceFav's published Chrome Web Store id (memory: salesforcefav-store-ids).
+// Included by default so an installed-from-store extension is detected without
+// the user hunting for its id; unpacked/dev builds pass their own id as args.
+const KNOWN_CHROME_EXT_ID = "jdhbfmfnmhmdcbjpojniceajeahbmpdg";
+
+function nmHostPath() {
+  return path.join(__dirname, "native-host.cjs");
+}
+
+function nmManifest(extIds) {
+  return {
+    name: NM_HOST_NAME,
+    description: "SalesForceFav CLI presence detector for the browser extension",
+    path: nmHostPath(),
+    type: "stdio",
+    allowed_origins: extIds.map((id) => `chrome-extension://${id}/`),
+  };
+}
+
+// Browser NativeMessagingHosts directories to install into, per OS. Only those
+// whose browser profile dir already exists are used (don't create config trees
+// for browsers that aren't installed). SFFAV_NM_DIR overrides everything — a
+// single explicit dir — which the test suite uses.
+function nmTargets() {
+  if (process.env.SFFAV_NM_DIR) {
+    return [
+      { browser: "SFFAV_NM_DIR", base: process.env.SFFAV_NM_DIR, dir: process.env.SFFAV_NM_DIR },
+    ];
+  }
+  const home = os.homedir();
+  let list = [];
+  if (process.platform === "darwin") {
+    const a = path.join(home, "Library", "Application Support");
+    list = [
+      ["Google Chrome", path.join(a, "Google", "Chrome")],
+      ["Microsoft Edge", path.join(a, "Microsoft Edge")],
+      ["Chromium", path.join(a, "Chromium")],
+      ["Brave", path.join(a, "BraveSoftware", "Brave-Browser")],
+    ];
+  } else if (process.platform === "linux") {
+    const c = path.join(home, ".config");
+    list = [
+      ["Google Chrome", path.join(c, "google-chrome")],
+      ["Microsoft Edge", path.join(c, "microsoft-edge")],
+      ["Chromium", path.join(c, "chromium")],
+      ["Brave", path.join(c, "BraveSoftware", "Brave-Browser")],
+    ];
+  }
+  return list.map(([browser, base]) => ({
+    browser,
+    base,
+    dir: path.join(base, "NativeMessagingHosts"),
+  }));
+}
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 const argv = process.argv.slice(2);
@@ -242,17 +309,114 @@ const commands = {
     out(`Imported ${added}, skipped ${skipped} duplicate(s).`);
   },
 
+  async "install-host"() {
+    const hostPath = nmHostPath();
+    if (!fs.existsSync(hostPath)) die(`native host not found at ${hostPath}`);
+    try {
+      fs.chmodSync(hostPath, 0o755); // must be executable for native messaging (no-op on Windows)
+    } catch {
+      /* best effort */
+    }
+    // Dedupe: the published Chrome id plus any ids the user passed.
+    const extIds = [KNOWN_CHROME_EXT_ID, ...positionals].filter(
+      (v, i, a) => v && a.indexOf(v) === i
+    );
+
+    if (process.platform === "win32") return installHostWindows(extIds);
+
+    const manifest = JSON.stringify(nmManifest(extIds), null, 2) + "\n";
+    let wrote = 0;
+    for (const t of nmTargets()) {
+      if (!process.env.SFFAV_NM_DIR && !fs.existsSync(t.base)) continue; // browser not installed
+      fs.mkdirSync(t.dir, { recursive: true });
+      const file = path.join(t.dir, `${NM_HOST_NAME}.json`);
+      fs.writeFileSync(file, manifest);
+      out(`  ✓ ${t.browser}: ${file}`);
+      wrote += 1;
+    }
+    if (wrote === 0)
+      return out("No Chrome/Edge/Chromium/Brave profile found — nothing to register.");
+    out(`\nRegistered "${NM_HOST_NAME}" for ${extIds.length} extension id(s):`);
+    extIds.forEach((id) => out(`  • chrome-extension://${id}/`));
+    if (positionals.length === 0) {
+      out(
+        "\nOnly the published Chrome id was registered. For an unpacked/dev build, re-run\n" +
+          "with your extension id (copy it from chrome://extensions):  sffav install-host <id>"
+      );
+    }
+    out("\nReopen the extension popup — the built-in authenticator will now appear.");
+  },
+
+  async "uninstall-host"() {
+    if (process.platform === "win32") return uninstallHostWindows();
+    let removed = 0;
+    for (const t of nmTargets()) {
+      const file = path.join(t.dir, `${NM_HOST_NAME}.json`);
+      if (fs.existsSync(file)) {
+        fs.rmSync(file);
+        out(`  ✓ removed ${file}`);
+        removed += 1;
+      }
+    }
+    out(removed ? `\nRemoved ${removed} host manifest(s).` : "No host manifest found.");
+  },
+
   help() {
     out(
       fs
         .readFileSync(__filename, "utf8")
         .split("\n")
-        .slice(3, 28)
+        .slice(3, 32)
         .join("\n")
         .replace(/^\/\/ ?/gm, "")
     );
   },
 };
+
+// Windows registers native hosts in the registry (not a dir), and the manifest
+// `path` must be an executable — so wrap node+script in a .cmd. Best-effort:
+// `reg` failures are reported, not fatal. Untested on CI (no Windows runner).
+function installHostWindows(extIds) {
+  const dir = path.join(process.env.APPDATA || os.homedir(), "SalesForceFav");
+  fs.mkdirSync(dir, { recursive: true });
+  const cmd = path.join(dir, "sffav-host.cmd");
+  fs.writeFileSync(cmd, `@echo off\r\nnode "${nmHostPath()}" %*\r\n`);
+  const file = path.join(dir, `${NM_HOST_NAME}.json`);
+  fs.writeFileSync(file, JSON.stringify({ ...nmManifest(extIds), path: cmd }, null, 2) + "\n");
+  const keys = [
+    `HKCU\\Software\\Google\\Chrome\\NativeMessagingHosts\\${NM_HOST_NAME}`,
+    `HKCU\\Software\\Microsoft\\Edge\\NativeMessagingHosts\\${NM_HOST_NAME}`,
+  ];
+  let ok = 0;
+  for (const key of keys) {
+    try {
+      execFileSync("reg", ["add", key, "/ve", "/t", "REG_SZ", "/d", file, "/f"], {
+        stdio: "ignore",
+      });
+      out(`  ✓ ${key}`);
+      ok += 1;
+    } catch (e) {
+      err(`  ! could not set ${key}: ${e.message}`);
+    }
+  }
+  out(
+    ok
+      ? `\nRegistered for ${extIds.length} extension id(s). Reopen the popup.`
+      : "No registry keys written."
+  );
+}
+
+function uninstallHostWindows() {
+  for (const browser of ["Google\\Chrome", "Microsoft\\Edge"]) {
+    const key = `HKCU\\Software\\${browser}\\NativeMessagingHosts\\${NM_HOST_NAME}`;
+    try {
+      execFileSync("reg", ["delete", key, "/f"], { stdio: "ignore" });
+      out(`  ✓ removed ${key}`);
+    } catch {
+      /* not present */
+    }
+  }
+}
 
 (async () => {
   const fn = commands[command] || (command ? null : commands.help);

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "1.9.7",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
-  "permissions": ["activeTab", "tabs", "scripting", "storage"],
+  "permissions": ["activeTab", "tabs", "scripting", "storage", "nativeMessaging"],
   "host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "background.js"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "salesforcefav-extension",
   "version": "1.9.7",
-  "private": true,
   "description": "SalesForceFav — a Manifest V3 Chrome/Edge extension that stores Salesforce credentials and automates login.",
   "type": "commonjs",
   "bin": {
     "sffav": "cli/sffav.cjs"
   },
+  "files": [
+    "cli/",
+    "popup/credentials.js"
+  ],
   "scripts": {
     "cli": "node cli/sffav.cjs",
     "lint": "eslint .",

--- a/popup/credentials.js
+++ b/popup/credentials.js
@@ -16,19 +16,26 @@
     production: "https://login.salesforce.com/",
   };
 
-  const ENVIRONMENTS = ["sandbox", "production", "sso"];
+  // "custom" is a My Domain login URL (https://acme.my.salesforce.com) with
+  // standard username/password fill — required for orgs that block the generic
+  // login.salesforce.com host ("Prevent login from login.salesforce.com").
+  const ENVIRONMENTS = ["sandbox", "production", "custom", "sso"];
 
   // Default tab/favicon color for new and imported credentials (matches the
   // CSS --accent token). Single source of truth so it can't drift.
   const DEFAULT_FAVICON_COLOR = "#3a5ccc";
 
-  // Resolve the URL to open for a credential. SSO uses the user-supplied URL;
-  // standard environments map to a fixed Salesforce host. Returns null when the
-  // environment is unknown or an SSO credential has no URL.
+  // Resolve the URL to open for a credential. SSO and custom (My Domain) use
+  // the user-supplied URL; standard environments map to a fixed Salesforce
+  // host. Returns null when the environment is unknown or a URL-based
+  // credential has no URL.
   function resolveSalesforceUrl(credential) {
     if (!credential) return null;
     if (credential.environment === "sso") {
       return credential.ssourl ? credential.ssourl : null;
+    }
+    if (credential.environment === "custom") {
+      return credential.customurl ? credential.customurl : null;
     }
     return SF_LOGIN_URLS[credential.environment] || null;
   }
@@ -86,6 +93,9 @@
         errors.ssourl = "Enter a valid SSO URL (http/https).";
       }
     } else if (ENVIRONMENTS.includes(c.environment)) {
+      if (c.environment === "custom" && !isValidHttpUrl(c.customurl)) {
+        errors.customurl = "Enter a valid My Domain URL (https://acme.my.salesforce.com).";
+      }
       if (!c.username || !String(c.username).trim()) {
         errors.username = "Username is required.";
       }
@@ -128,13 +138,22 @@
     return [(bigint >> 16) & 255, (bigint >> 8) & 255, bigint & 255];
   }
 
+  const STALE_DAYS = 90;
+
   // Security health audit over the saved credentials. Returns the groups of orgs
   // that share a password and the orgs without 2FA. SSO orgs are excluded from
   // both (their password is empty and their MFA lives at the identity provider).
-  function auditCredentials(credentials) {
+  // `stale` (orgs unused for 90+ days) is informational, not a security issue —
+  // it's reported separately and left out of `issues` on purpose, so it doesn't
+  // shift the meaning of an existing, already-relied-on count. `nowMs` is taken
+  // as a parameter (never Date.now() internally) to keep this deterministic and
+  // testable, matching the rest of this module's convention (see totp()).
+  function auditCredentials(credentials, nowMs) {
     const list = Array.isArray(credentials) ? credentials : [];
+    const now = typeof nowMs === "number" ? nowMs : Date.now();
     const byPassword = new Map();
     const noTwoFactor = [];
+    const stale = [];
     for (const c of list) {
       if (!c || c.environment === "sso") continue;
       if (c.password) {
@@ -142,11 +161,15 @@
         byPassword.get(c.password).push(c.credentialName);
       }
       if (!c.totp || !String(c.totp).trim()) noTwoFactor.push(c.credentialName);
+      if (c.lastUsedAt && now - c.lastUsedAt > STALE_DAYS * 24 * 60 * 60 * 1000) {
+        stale.push(c.credentialName);
+      }
     }
     const reusedGroups = [...byPassword.values()].filter((names) => names.length > 1);
     return {
       reusedGroups,
       noTwoFactor,
+      stale,
       issues: reusedGroups.length + noTwoFactor.length,
     };
   }
@@ -425,6 +448,7 @@
       credentialName: String(raw.credentialName || "").trim(),
       environment: raw.environment || "",
       ssourl: raw.ssourl || "",
+      customurl: raw.customurl || "",
       username: raw.username || "",
       password: raw.password || "",
       faviconColor: raw.faviconColor || DEFAULT_FAVICON_COLOR,

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -213,6 +213,49 @@ body {
   color: var(--accent);
 }
 
+/* ── card overflow menu (rendered into #cardMenuPortal, see popup.js) ── */
+.card-menu-list {
+  position: fixed;
+  z-index: 1000;
+  min-width: 180px;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(20, 25, 40, 0.16);
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.card-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 12.5px;
+  text-align: left;
+  padding: 7px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.card-menu-item:hover {
+  background: var(--surface-2);
+}
+.card-menu-item.danger {
+  color: var(--danger);
+}
+.card-menu-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+}
+.card-menu-icon svg {
+  width: 15px;
+  height: 15px;
+}
+
 /* ── form action buttons (text) ── */
 .form-actions .btn {
   width: auto;
@@ -273,6 +316,34 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+/* Hover-to-copy: username/password icons that fade in on card hover (and stay
+   visible while keyboard-focused). flex-shrink:0 so a long name ellipsizes
+   instead of squashing the buttons. */
+.cred-copy {
+  display: inline-flex;
+  flex-shrink: 0;
+  gap: 2px;
+  margin-left: 2px;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.cred-card:hover .cred-copy,
+.cred-copy:focus-within {
+  opacity: 1;
+}
+.cred-copy-btn {
+  width: 22px;
+  height: 22px;
+}
+.cred-copy-btn svg {
+  width: 14px;
+  height: 14px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cred-copy {
+    transition: none;
+  }
+}
 .cred-meta {
   display: flex;
   align-items: center;
@@ -310,6 +381,10 @@ body {
   color: #5b53b5;
   background: rgba(91, 83, 181, 0.12);
 }
+.env-custom {
+  color: #0e7490;
+  background: rgba(14, 116, 144, 0.12);
+}
 html[data-theme="dark"] .env-sandbox {
   color: #e0b257;
 }
@@ -319,12 +394,17 @@ html[data-theme="dark"] .env-production {
 html[data-theme="dark"] .env-sso {
   color: #a9a2ef;
 }
+html[data-theme="dark"] .env-custom {
+  color: #67cfe3;
+}
 .cred-actions {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 0;
-  max-width: 120px;
+  gap: 1px;
+  /* 5 primary actions now (open, more, pin, edit, delete) — was 9 before the
+     overflow menu, which is what the old, tighter cap was sized for. */
+  max-width: 170px;
 }
 
 /* ── live 2FA code chip ── */
@@ -491,6 +571,74 @@ html[data-theme="dark"] .env-sso {
   padding: 6px 12px;
   font-size: 12px;
 }
+
+/* ── in-form 2FA authenticator (Add/Edit form) ── */
+#totpFieldContainer .field-opt {
+  font-weight: 400;
+  color: var(--text-muted);
+}
+.totp-input-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.totp-input-row input {
+  flex: 1;
+}
+.totp-input-row .btn,
+.btn-small {
+  width: auto;
+  height: auto;
+  padding: 7px 12px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+.totp-enroll {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  margin-top: 10px;
+  padding: 10px;
+  background: var(--accent-soft);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+/* display:flex above would defeat the [hidden] attribute, so re-assert it. */
+.totp-enroll[hidden] {
+  display: none;
+}
+.totp-enroll-side {
+  flex: 1;
+  min-width: 132px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.totp-live {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.totp-live-code {
+  font:
+    700 18px/1 "SF Mono",
+    ui-monospace,
+    monospace;
+  letter-spacing: 2px;
+  color: var(--accent);
+}
+.totp-live-left {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.totp-hint {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--text-muted);
+}
 .form-row {
   display: flex;
   align-items: center;
@@ -522,6 +670,65 @@ html[data-theme="dark"] .env-sso {
   justify-content: flex-end;
   gap: 8px;
   margin-top: 16px;
+}
+
+/* ── security audit panel ── */
+.audit-card {
+  padding: 12px 14px 14px;
+}
+.audit-clean {
+  margin: 4px 0 0;
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+.audit-section {
+  margin-top: 12px;
+}
+.audit-section h3 {
+  margin: 0 0 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--text-muted);
+}
+.audit-section.audit-informational h3 {
+  color: var(--text-muted);
+  opacity: 0.8;
+}
+.audit-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 4px;
+  border-bottom: 1px solid var(--border);
+}
+.audit-row:last-child {
+  border-bottom: none;
+}
+.audit-row-name {
+  background: none;
+  border: none;
+  color: var(--text);
+  font-size: 12.5px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  padding: 2px 0;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  transition: text-decoration-color 0.12s ease;
+}
+.audit-row-name:hover {
+  text-decoration-color: var(--text-muted);
+}
+.audit-row-action {
+  width: auto;
+  height: auto;
+  padding: 5px 10px;
+  font-size: 11.5px;
+  flex-shrink: 0;
 }
 .form-errors {
   background: rgba(192, 57, 43, 0.08);
@@ -648,6 +855,35 @@ body.sff-locked #formContainer {
   width: 100%;
   font-size: 12px;
   color: var(--danger);
+}
+.lock-device {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+.lock-device-icon {
+  display: inline-flex;
+  line-height: 0;
+}
+/* "or use your passphrase" divider between the biometric button and the field */
+.lock-or {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 2px 0;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.lock-or::before,
+.lock-or::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+.lock-or[hidden] {
+  display: none;
 }
 .lock-reset {
   background: none;

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -577,6 +577,27 @@ html[data-theme="dark"] .env-custom {
   font-weight: 400;
   color: var(--text-muted);
 }
+/* Shown in place of the authenticator controls when the sffav CLI isn't found. */
+.totp-cli-hint {
+  margin-top: 10px;
+  padding: 9px 11px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-muted);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.totp-cli-hint code {
+  font:
+    600 11px/1 "SF Mono",
+    ui-monospace,
+    monospace;
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 1px 4px;
+  border-radius: 4px;
+}
 .totp-input-row {
   display: flex;
   gap: 6px;

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <title>SalesForceFav</title>
     <link rel="stylesheet" href="popup.css" />
-    <script defer src="vendor/qrcode.js"></script>
     <script defer src="credentials.js"></script>
     <script defer src="cryptovault.js"></script>
+    <script defer src="vendor/qrcode.js"></script>
     <script defer src="popup.js"></script>
   </head>
   <body>
@@ -43,6 +43,13 @@
             <span class="audit-badge" id="auditBadge"></span>
           </button>
           <button
+            id="deviceUnlockToggle"
+            class="icon-btn"
+            title="Enable biometric unlock"
+            aria-label="Enable biometric unlock"
+            hidden
+          ></button>
+          <button
             id="themeToggle"
             class="icon-btn"
             title="Toggle theme"
@@ -73,6 +80,7 @@
       </div>
 
       <div id="formContainer" class="form-panel" hidden></div>
+      <div id="auditPanel" class="form-panel" hidden></div>
 
       <ul id="credentialList" class="cred-list"></ul>
 
@@ -93,6 +101,12 @@
           <img class="lock-logo" src="../icons/icon-128.png" alt="" />
           <h2 id="lockTitle">Vault locked</h2>
           <p id="lockHint" class="lock-hint"></p>
+
+          <button id="lockDeviceBtn" class="btn btn-primary lock-device" type="button" hidden>
+            <span class="lock-device-icon" id="lockDeviceIcon" aria-hidden="true"></span>
+            <span id="lockDeviceLabel">Use biometric unlock</span>
+          </button>
+          <div id="lockOr" class="lock-or" hidden>or use your passphrase</div>
 
           <div class="lock-pw">
             <input
@@ -116,5 +130,8 @@
         </div>
       </div>
     </div>
+    <!-- Portal for per-card overflow menus: rendered here (not as a card
+         child) so they aren't clipped by .cred-card's overflow:hidden. -->
+    <div id="cardMenuPortal"></div>
   </body>
 </html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -3,13 +3,69 @@
 //
 // Pure logic (validation, search, sort, import/export) lives in credentials.js
 // (exposed as SFFav) and is unit-tested. This file owns the DOM, chrome.* calls,
-// and localStorage. Credential-derived strings are rendered via textContent only
+// and storage. Credential-derived strings are rendered via textContent only
 // (never innerHTML) so an imported backup file can't inject markup.
 // ─────────────────────────────────────────────────────────────────────────────
 
+// ── storage map ──────────────────────────────────────────────────────────────
+// Credential data lives in chrome.storage.local (durable across the profile;
+// unlike localStorage it is not subject to browser storage-pressure eviction),
+// accessed through a synchronous in-memory mirror (`store`) loaded once at
+// startup by initStore(). Legacy localStorage values are migrated on first run.
+// Values are kept as the same JSON strings the localStorage era used, so the
+// vault format — and therefore CLI backup-file compatibility — is unchanged.
+//
+//   Key                 | API                  | Lifecycle
+//   --------------------|----------------------|---------------------------------
+//   STORAGE_KEY          | chrome.storage.local | Permanent. Legacy plaintext
+//                        |  (via `store`)       | credential list (pre-encryption).
+//   VAULT_KEY            | chrome.storage.local | Permanent. Encrypted credential
+//                        |  (via `store`)       | list, once encryption is enabled
+//                        |                      | (replaces STORAGE_KEY).
+//   DEVICE_UNLOCK_KEY     | chrome.storage.local | Permanent until disabled. Touch
+//                        |  (via `store`)       | ID/Hello record: {credentialId,
+//                        |                      | salt, wrapped: <passphrase
+//                        |                      | encrypted under the PRF secret>}.
+//   THEME_KEY            | localStorage         | Permanent. Light/dark preference.
+//                        |                      | Stays in localStorage on purpose:
+//                        |                      | it's read synchronously before
+//                        |                      | first paint (async would flash
+//                        |                      | the wrong theme) and is cosmetic.
+//   PENDING_TOTP_KEY      | chrome.storage.local | Ephemeral. Queue of {credential
+//                        |  (direct, async)     | Name, secret} written by
+//                        |                      | background.js after the on-page
+//                        |                      | 2FA setup card, drained by
+//                        |                      | applyPendingTotp() into the real
+//                        |                      | (VAULT_KEY/STORAGE_KEY) list on
+//                        |                      | next popup open/unlock. Matched
+//                        |                      | by credentialName only — a
+//                        |                      | duplicate name would misapply.
+//   SESSION_PASS_KEY      | chrome.storage.     | Per-session. The passphrase,
+//                        |  session (async)     | held so re-opening the popup
+//                        |                      | doesn't re-prompt. Memory-only,
+//                        |                      | wiped when the browser quits or
+//                        |                      | on "Lock now". Never on disk.
+//
+// Only VAULT_KEY/STORAGE_KEY are the actual source of truth for credentials;
+// DEVICE_UNLOCK_KEY and PENDING_TOTP_KEY are narrow, single-purpose handoffs.
+// Security note: chrome.storage.local is plaintext-on-disk in the Chrome
+// profile, exactly like localStorage was — at-rest confidentiality comes from
+// the AES-256-GCM vault (cryptovault.js), not from the storage layer, and the
+// migration doesn't change that model.
 const STORAGE_KEY = "credentials"; // legacy plaintext (pre-encryption)
 const VAULT_KEY = "sffav-vault"; // encrypted blob (when encryption is enabled)
 const THEME_KEY = "sffav-theme";
+// chrome.storage.local key background.js stages generated 2FA keys under —
+// see the matching constant and comment in background.js.
+const PENDING_TOTP_KEY = "sffav-pending-totp";
+// Key for the Touch ID / Windows Hello convenience unlock — see the
+// device-unlock section below.
+const DEVICE_UNLOCK_KEY = "sffav-device-unlock";
+// chrome.storage.session key holding the passphrase for the current browser
+// session, so re-opening the popup doesn't re-prompt. session storage is
+// memory-only, wiped when the browser fully quits, and unreadable by content
+// scripts — see the "stay unlocked" section below.
+const SESSION_PASS_KEY = "sffav-session-pass";
 
 // In-memory view state. `credentials` is the source of truth (mirrors storage).
 // `passphrase` is held only while unlocked (cleared on lock / popup close).
@@ -20,23 +76,145 @@ const state = {
   passphrase: null,
 };
 
-const isEncrypted = () => localStorage.getItem(VAULT_KEY) !== null;
+// ── persisted-key mirror ─────────────────────────────────────────────────────
+// In-memory mirror of the chrome.storage.local keys, so the rest of the file
+// can keep reading synchronously. initStore() fills it once at startup (and
+// migrates any legacy localStorage values); storeSet/storeRemove write through
+// to chrome.storage.local. Values are raw JSON strings, same as before.
+const store = { [STORAGE_KEY]: null, [VAULT_KEY]: null, [DEVICE_UNLOCK_KEY]: null };
 
-document.addEventListener("DOMContentLoaded", function () {
+async function initStore() {
+  const keys = [STORAGE_KEY, VAULT_KEY, DEVICE_UNLOCK_KEY];
+  let got = {};
+  try {
+    got = await chrome.storage.local.get(keys);
+  } catch (e) {
+    console.error("SalesForceFav: storage read failed:", e);
+  }
+  for (const key of keys) {
+    if (typeof got[key] === "string") {
+      store[key] = got[key];
+      continue;
+    }
+    // One-time migration from the localStorage era. Copy first and only then
+    // delete, so a failed write can't lose the only copy.
+    const legacy = localStorage.getItem(key);
+    if (legacy !== null) {
+      store[key] = legacy;
+      try {
+        await chrome.storage.local.set({ [key]: legacy });
+        localStorage.removeItem(key);
+      } catch (e) {
+        console.error("SalesForceFav: storage migration failed for", key, e);
+      }
+    }
+  }
+}
+
+function storeGet(key) {
+  return store[key]; // JSON string, or null when unset
+}
+
+function storeSet(key, value) {
+  store[key] = value;
+  chrome.storage.local.set({ [key]: value });
+}
+
+function storeRemove(key) {
+  store[key] = null;
+  chrome.storage.local.remove(key);
+}
+
+// ── stay unlocked for the browser session ────────────────────────────────────
+// The passphrase lives in memory only while the popup is open, and the popup is
+// a fresh page load every time it opens — so without this it would re-prompt on
+// every open. Caching the passphrase in chrome.storage.session (memory-only,
+// wiped when the browser fully quits, isolated to this extension) lets the popup
+// silently re-derive the vault on open until the user quits the browser or hits
+// "Lock now". All three helpers swallow errors: a missing/blocked session store
+// simply falls back to the normal passphrase prompt.
+async function sessionRememberPass(pass) {
+  try {
+    await chrome.storage.session.set({ [SESSION_PASS_KEY]: pass });
+  } catch {
+    /* no session storage → user just re-enters the passphrase next open */
+  }
+}
+async function sessionGetPass() {
+  try {
+    const got = await chrome.storage.session.get(SESSION_PASS_KEY);
+    return typeof got[SESSION_PASS_KEY] === "string" ? got[SESSION_PASS_KEY] : null;
+  } catch {
+    return null;
+  }
+}
+async function sessionForgetPass() {
+  try {
+    await chrome.storage.session.remove(SESSION_PASS_KEY);
+  } catch {
+    /* best effort */
+  }
+}
+
+const isEncrypted = () => storeGet(VAULT_KEY) !== null;
+
+document.addEventListener("DOMContentLoaded", async function () {
   paintStaticIcons();
   applyTheme(localStorage.getItem(THEME_KEY) || "light");
   wireToolbar();
   wireLock();
+  await initStore();
+  probePlatformAuth(); // async; re-renders the biometric affordances when it resolves
   updateLockButton();
+  updateDeviceUnlockButton();
   if (isEncrypted()) {
-    // Vault exists → start locked; credentials load only after unlock.
-    showLock("unlock");
+    // Vault exists. Try to resume this browser session silently; only fall back
+    // to the lock screen when there's no cached passphrase (or it's stale).
+    const resumed = await tryResumeSession();
+    if (!resumed) showLock("unlock");
   } else {
     state.credentials = loadCredentials();
     render();
+    applyPendingTotp();
   }
   setInterval(updateTotpChips, 1000); // live 2FA codes + countdown
 });
+
+// Adopt any 2FA keys generated by the post-login setup prompt (background.js)
+// into their matching credential, now that we have a writable — and if
+// applicable, unlocked — copy of state.credentials to persist() through.
+// Entries that don't match a credential yet (e.g. it was renamed, or the
+// vault is still locked) are left staged for the next call.
+async function applyPendingTotp() {
+  let pending;
+  try {
+    const stored = await chrome.storage.local.get(PENDING_TOTP_KEY);
+    pending = Array.isArray(stored[PENDING_TOTP_KEY]) ? stored[PENDING_TOTP_KEY] : [];
+  } catch {
+    return;
+  }
+  if (!pending.length) return;
+
+  const remaining = [];
+  let applied = 0;
+  for (const entry of pending) {
+    const match = state.credentials.find(
+      (c) => c.credentialName === entry.credentialName && !c.totp
+    );
+    if (match && SFFav.isValidTotpSecret(entry.secret)) {
+      match.totp = entry.secret;
+      applied++;
+    } else {
+      remaining.push(entry);
+    }
+  }
+  await chrome.storage.local.set({ [PENDING_TOTP_KEY]: remaining });
+  if (applied) {
+    await persist();
+    render();
+    toast(applied === 1 ? "2FA key saved for 1 org" : `2FA keys saved for ${applied} orgs`);
+  }
+}
 
 // Refresh every visible 2FA chip: current code (grouped "123 456") and a ring
 // that shrinks over the 30s window. Reads the secret from the element property.
@@ -60,13 +238,14 @@ function paintStaticIcons() {
   setIcon($("importBtn"), "upload");
   setIcon($("exportBtn"), "download");
   setIcon($("emptyIcon"), "bolt");
+  setIcon($("lockDeviceIcon"), "fingerprint");
 }
 
 // ── persistence ──────────────────────────────────────────────────────────────
 
 function loadCredentials() {
   try {
-    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    const parsed = JSON.parse(storeGet(STORAGE_KEY));
     return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
@@ -81,7 +260,7 @@ function persist() {
   if (state.passphrase) {
     return SFVault.encrypt({ credentials: state.credentials }, state.passphrase)
       .then((vault) => {
-        localStorage.setItem(VAULT_KEY, JSON.stringify(vault));
+        storeSet(VAULT_KEY, JSON.stringify(vault));
         return true;
       })
       .catch((e) => {
@@ -90,7 +269,7 @@ function persist() {
         return false;
       });
   }
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(state.credentials));
+  storeSet(STORAGE_KEY, JSON.stringify(state.credentials));
   return Promise.resolve(true);
 }
 
@@ -127,11 +306,220 @@ function disableEncryption() {
       "needed to open the popup). You can re-enable encryption anytime. Continue?"
   );
   if (!ok) return;
+  sessionForgetPass(); // no vault to resume anymore
   state.passphrase = null; // persist() now writes the legacy plaintext key
   persist();
-  localStorage.removeItem(VAULT_KEY);
+  storeRemove(VAULT_KEY);
+  storeRemove(DEVICE_UNLOCK_KEY); // device unlock only makes sense on top of the encrypted vault
   updateLockButton();
+  updateDeviceUnlockButton();
   toast("Encryption turned off");
+}
+
+// ── device unlock (Touch ID / Windows Hello) ─────────────────────────────────
+// A convenience shortcut layered on the passphrase vault, not a replacement:
+// the passphrase is required to enable this (proves the vault is already
+// unlockable) and is the ONLY recovery path on a new device/profile/OS
+// install, since the platform authenticator's derived secret never leaves
+// this machine. Uses the WebAuthn `prf` extension — the same (credential,
+// salt) pair deterministically re-derives the same secret, so it works as a
+// symmetric key without the authenticator ever exposing one.
+//
+// Design: reuse SFVault's existing PBKDF2/AES-GCM vault format to wrap the
+// real passphrase under the PRF-derived secret (base64-encoded, fed in as if
+// it were itself a passphrase) — no new crypto primitive to review, just a
+// second, smaller vault stored alongside the real one.
+
+// Whether THIS machine actually has a usable platform authenticator (Touch ID,
+// Windows Hello, Android biometrics). The bare API-presence check (PublicKeyCredential
+// exists) is true even on desktops with no biometric hardware, which is why the
+// biometric affordances used to appear where they could never work. The real
+// answer comes from isUserVerifyingPlatformAuthenticatorAvailable(), which is
+// async — so we probe once at startup, cache the result, and re-render.
+let platformAuthAvailable = false;
+async function probePlatformAuth() {
+  try {
+    platformAuthAvailable =
+      typeof PublicKeyCredential !== "undefined" &&
+      !!navigator.credentials &&
+      typeof PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable === "function" &&
+      (await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable());
+  } catch {
+    platformAuthAvailable = false; // some browsers reject instead of resolving false
+  }
+  updateDeviceUnlockButton(); // reveal/refresh the biometric UI now that we know
+}
+const deviceUnlockSupported = () => platformAuthAvailable;
+const hasDeviceUnlock = () => storeGet(DEVICE_UNLOCK_KEY) !== null;
+
+function bytesToB64(bytes) {
+  let s = "";
+  for (let i = 0; i < bytes.length; i += 1) s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+function b64ToBytes(str) {
+  return Uint8Array.from(atob(str), (c) => c.charCodeAt(0));
+}
+
+// Run the WebAuthn assertion ceremony and return the PRF secret, base64-encoded.
+async function getDevicePrfSecret(credentialId, salt) {
+  const assertion = await navigator.credentials.get({
+    publicKey: {
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      allowCredentials: [{ id: credentialId, type: "public-key" }],
+      userVerification: "required",
+      extensions: { prf: { eval: { first: salt } } },
+    },
+  });
+  const results = assertion.getClientExtensionResults();
+  const secret = results && results.prf && results.prf.results && results.prf.results.first;
+  if (!secret) throw new Error("This device didn't return a usable key.");
+  return bytesToB64(new Uint8Array(secret));
+}
+
+// The platform authenticator's name is OS-specific — "Touch ID" on Apple,
+// "Windows Hello" on Windows — so show only the one that applies rather than
+// both. Everything reachable here has already passed the availability probe, so
+// the biometric path is always offered as an alternative to (an OR with) the
+// master passphrase, never a replacement for it. Falls back to a generic label
+// on Linux/ChromeOS/Android where the built-in authenticator has no one brand.
+function deviceUnlockNoun() {
+  const uaPlatform = (navigator.userAgentData && navigator.userAgentData.platform) || "";
+  const plat = (uaPlatform || navigator.platform || navigator.userAgent || "").toLowerCase();
+  if (/mac|iphone|ipad|ios/.test(plat)) return "Touch ID";
+  if (/win/.test(plat)) return "Windows Hello";
+  return "biometric unlock";
+}
+
+function updateDeviceUnlockButton() {
+  const noun = deviceUnlockNoun();
+  const toggle = $("deviceUnlockToggle");
+  if (toggle) {
+    const show = deviceUnlockSupported() && isEncrypted() && !!state.passphrase;
+    toggle.hidden = !show;
+    if (show) {
+      const on = hasDeviceUnlock();
+      setIcon(toggle, "fingerprint");
+      toggle.classList.toggle("on", on);
+      toggle.title = on ? `${noun} unlock is on — click to turn off` : `Enable ${noun} unlock`;
+      toggle.setAttribute("aria-label", toggle.title);
+    }
+  }
+  // Lock-screen button label follows the OS too ("Use Touch ID" / "Use Windows
+  // Hello"), set here since the static HTML can't know the platform.
+  const lockDeviceLabel = $("lockDeviceLabel");
+  if (lockDeviceLabel) lockDeviceLabel.textContent = `Use ${noun}`;
+  // Lock screen: when this device has biometric unlock enrolled, make it the
+  // prominent action — show the Touch ID / Windows Hello button on top, an
+  // "or use your passphrase" divider, and demote the passphrase Unlock button
+  // to a secondary style. When it's not enrolled, the passphrase stays primary
+  // and the biometric row is hidden entirely.
+  const bioReady = deviceUnlockSupported() && hasDeviceUnlock();
+  const lockDeviceBtn = $("lockDeviceBtn");
+  const lockOr = $("lockOr");
+  const lockBtn = $("lockBtn");
+  const inSetup = $("lockScreen") && $("lockScreen").dataset.mode === "setup";
+  if (lockDeviceBtn) lockDeviceBtn.hidden = !bioReady || inSetup;
+  if (lockOr) lockOr.hidden = !bioReady || inSetup;
+  // The passphrase submit is primary everywhere except when biometric is the
+  // headline action on the unlock screen.
+  if (lockBtn) lockBtn.classList.toggle("btn-primary", !(bioReady && !inSetup));
+}
+
+// Registers a platform-authenticator credential and wraps the CURRENT
+// passphrase under its PRF secret. Only reachable while unlocked, so the
+// passphrase is always known here — see the header comment above.
+async function enableDeviceUnlock() {
+  if (!state.passphrase) return;
+  try {
+    const salt = crypto.getRandomValues(new Uint8Array(32));
+    const cred = await navigator.credentials.create({
+      publicKey: {
+        rp: { name: "SalesForceFav" }, // no id — browser uses this extension's origin
+        user: {
+          id: crypto.getRandomValues(new Uint8Array(16)),
+          name: "sffav-device-unlock",
+          displayName: "SalesForceFav vault unlock",
+        },
+        challenge: crypto.getRandomValues(new Uint8Array(32)),
+        // ES256 + RS256 — Chrome's recommended default pair; some authenticators
+        // (older security keys, certain TPM-backed Windows Hello setups) only
+        // support RS256, and registration can fail without it as a fallback.
+        pubKeyCredParams: [
+          { type: "public-key", alg: -7 }, // ES256
+          { type: "public-key", alg: -257 }, // RS256
+        ],
+        authenticatorSelection: {
+          authenticatorAttachment: "platform",
+          userVerification: "required",
+        },
+        // Ask for the secret in this same ceremony — some platform authenticators
+        // return it directly from create(), saving the user a second prompt.
+        extensions: { prf: { eval: { first: salt } } },
+      },
+    });
+    const createSecret = cred.getClientExtensionResults()?.prf?.results?.first;
+    // Most authenticators only confirm PRF *support* during registration and
+    // hand over the actual secret on a follow-up assertion — fall back to
+    // that (a second prompt) only when this device didn't provide it above.
+    const secretB64 = createSecret
+      ? bytesToB64(new Uint8Array(createSecret))
+      : await getDevicePrfSecret(cred.rawId, salt);
+    const wrapped = await SFVault.encrypt({ passphrase: state.passphrase }, secretB64);
+    storeSet(
+      DEVICE_UNLOCK_KEY,
+      JSON.stringify({
+        credentialId: bytesToB64(new Uint8Array(cred.rawId)),
+        salt: bytesToB64(salt),
+        wrapped,
+      })
+    );
+    updateDeviceUnlockButton();
+    toast(`${deviceUnlockNoun()} unlock enabled`);
+  } catch (e) {
+    console.error("SalesForceFav: enabling device unlock failed:", e);
+    toast("Couldn't enable device unlock");
+  }
+}
+
+function disableDeviceUnlock() {
+  storeRemove(DEVICE_UNLOCK_KEY);
+  updateDeviceUnlockButton();
+  toast("Device unlock turned off");
+}
+
+// Unlocks the real vault via the platform authenticator instead of a typed
+// passphrase. Any failure (cancelled prompt, tampered storage, unsupported
+// device) falls back to lockError — the passphrase field is always right
+// there, since it's the only recovery path if this doesn't work.
+async function onDeviceUnlockClick() {
+  let record;
+  try {
+    record = JSON.parse(storeGet(DEVICE_UNLOCK_KEY));
+  } catch {
+    record = null;
+  }
+  if (!record) return;
+  try {
+    const secretB64 = await getDevicePrfSecret(
+      b64ToBytes(record.credentialId),
+      b64ToBytes(record.salt)
+    );
+    const unwrapped = await SFVault.decrypt(record.wrapped, secretB64);
+    const vault = JSON.parse(storeGet(VAULT_KEY));
+    const data = await SFVault.decrypt(vault, unwrapped.passphrase);
+    state.credentials = Array.isArray(data.credentials) ? data.credentials : [];
+    state.passphrase = unwrapped.passphrase;
+    sessionRememberPass(unwrapped.passphrase); // stay unlocked for the rest of this browser session
+    hideLock();
+    updateLockButton();
+    updateDeviceUnlockButton();
+    render();
+    applyPendingTotp();
+  } catch (e) {
+    console.error("SalesForceFav: device unlock failed:", e);
+    lockError("Device unlock failed — enter your passphrase instead.");
+  }
 }
 
 function wireLock() {
@@ -149,6 +537,18 @@ function wireLock() {
   if (lockReset) lockReset.addEventListener("click", resetVault);
   const encDisable = $("encDisable");
   if (encDisable) encDisable.addEventListener("click", disableEncryption);
+  const lockDeviceBtn = $("lockDeviceBtn");
+  if (lockDeviceBtn) lockDeviceBtn.addEventListener("click", onDeviceUnlockClick);
+  const deviceUnlockToggle = $("deviceUnlockToggle");
+  if (deviceUnlockToggle) {
+    deviceUnlockToggle.addEventListener("click", () => {
+      if (hasDeviceUnlock()) {
+        if (confirm(`Turn off ${deviceUnlockNoun()} unlock on this device?`)) disableDeviceUnlock();
+      } else {
+        enableDeviceUnlock();
+      }
+    });
+  }
   const lockPass = $("lockPass");
   if (lockPass) {
     lockPass.addEventListener("keydown", (e) => {
@@ -186,6 +586,7 @@ function showLock(mode) {
 
   $("lockError").hidden = true;
   $("lockPass").value = "";
+  updateDeviceUnlockButton(); // shows the lock-screen Touch ID/Hello button when set up
   screen.hidden = false;
   document.body.classList.add("sff-locked"); // hide app chrome behind the lock card
   $("lockPass").focus();
@@ -205,6 +606,29 @@ function lockError(msg) {
   el.hidden = false;
 }
 
+// Silently re-open the vault from the session-cached passphrase (see
+// sessionRememberPass). Returns true when the popup is now unlocked; false when
+// there's nothing cached or the cache no longer decrypts the current vault (in
+// which case it's cleared so the user gets a clean passphrase prompt).
+async function tryResumeSession() {
+  const pass = await sessionGetPass();
+  if (!pass) return false;
+  try {
+    const vault = JSON.parse(storeGet(VAULT_KEY));
+    const data = await SFVault.decrypt(vault, pass);
+    state.credentials = Array.isArray(data.credentials) ? data.credentials : [];
+    state.passphrase = pass;
+    updateLockButton();
+    updateDeviceUnlockButton();
+    render();
+    applyPendingTotp();
+    return true;
+  } catch {
+    await sessionForgetPass();
+    return false;
+  }
+}
+
 async function onLockSubmit() {
   const mode = $("lockScreen").dataset.mode;
   const pass = $("lockPass").value;
@@ -219,9 +643,11 @@ async function onLockSubmit() {
       state.passphrase = null;
       return lockError("Couldn't enable encryption — please try again.");
     }
-    localStorage.removeItem(STORAGE_KEY);
+    storeRemove(STORAGE_KEY);
+    sessionRememberPass(pass); // stay unlocked for the rest of this browser session
     hideLock();
     updateLockButton();
+    updateDeviceUnlockButton();
     render();
     toast("Encryption enabled");
     return;
@@ -229,13 +655,16 @@ async function onLockSubmit() {
 
   // unlock
   try {
-    const vault = JSON.parse(localStorage.getItem(VAULT_KEY));
+    const vault = JSON.parse(storeGet(VAULT_KEY));
     const data = await SFVault.decrypt(vault, pass);
     state.credentials = Array.isArray(data.credentials) ? data.credentials : [];
     state.passphrase = pass;
+    sessionRememberPass(pass); // stay unlocked for the rest of this browser session
     hideLock();
     updateLockButton();
+    updateDeviceUnlockButton();
     render();
+    applyPendingTotp();
   } catch (e) {
     lockError(e.message || "Could not unlock.");
     // Offer the reset escape hatch only once the user has actually failed to unlock.
@@ -252,17 +681,21 @@ function resetVault() {
     "Reset will DELETE the encrypted vault and start fresh (you'll re-add your orgs).\n\n" +
     "If you have a backup file you can restore it afterwards. Continue?";
   if (!confirm(msg)) return;
-  localStorage.removeItem(VAULT_KEY);
-  localStorage.removeItem(STORAGE_KEY);
+  sessionForgetPass();
+  storeRemove(VAULT_KEY);
+  storeRemove(STORAGE_KEY);
+  storeRemove(DEVICE_UNLOCK_KEY); // the wrapped passphrase is unrecoverable without the vault anyway
   state.passphrase = null;
   state.credentials = [];
   hideLock();
   updateLockButton();
+  updateDeviceUnlockButton();
   render();
   toast("Vault reset — encryption is off");
 }
 
 function lock() {
+  sessionForgetPass(); // "Lock now" ends the stay-unlocked session
   state.passphrase = null;
   state.credentials = [];
   state.query = "";
@@ -287,6 +720,13 @@ function sendLogin(credential, loginType) {
   chrome.runtime.sendMessage({ type: "sffav-login", credential, loginType });
 }
 
+// Explicit, on-demand 2FA setup — logs in and shows the QR on the page, but
+// only when the user asks for it via the "Set up 2FA" button (never
+// automatically on a plain login).
+function sendSetupTotp(credential) {
+  chrome.runtime.sendMessage({ type: "sffav-setup-totp", credential });
+}
+
 const openInWindow = (credential) => sendLogin(credential, "newWindow");
 const openIncognito = (credential) => sendLogin(credential, "incognito");
 const openInTab = (credential) => sendLogin(credential, "newTab");
@@ -298,6 +738,7 @@ const openInTab = (credential) => sendLogin(credential, "newTab");
 const ENV_META = {
   sandbox: { label: "Sandbox", cls: "env-sandbox" },
   production: { label: "Production", cls: "env-production" },
+  custom: { label: "My Domain", cls: "env-custom" },
   sso: { label: "SSO", cls: "env-sso" },
 };
 
@@ -329,6 +770,11 @@ const ICONS = {
   close: '<line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>',
   bolt: '<polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>',
   shield: '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>',
+  "shield-off":
+    '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><line x1="4" y1="3" x2="20" y2="21"/>',
+  fingerprint:
+    '<path d="M12 11a3 3 0 0 0-3 3c0 2 1 3 1 5"/><path d="M18 11a6 6 0 0 0-9.33-5"/><path d="M6 14a6 6 0 0 0 1 5"/><path d="M9 14a3 3 0 0 1 6 0c0 3-2 4-2 6"/><path d="M3 11a9 9 0 0 1 15.6-6.1"/><path d="M21 11a9 9 0 0 1-2.2 6.1"/>',
+  more: '<circle cx="12" cy="5" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="12" cy="19" r="1.6"/>',
 };
 
 // Return SVG markup for an icon. `fill` makes a solid glyph (used for pins).
@@ -357,6 +803,16 @@ function wireToolbar() {
       state.query = search.value;
       render();
     });
+    // Enter launches the top match in a new tab — type a few letters, hit
+    // Enter, logged in. The list is already sorted pinned-first/most-recent,
+    // so the top match is the likeliest target.
+    search.addEventListener("keydown", (e) => {
+      if (e.key !== "Enter") return;
+      const visible = SFFav.sortCredentials(
+        SFFav.filterCredentials(state.credentials, state.query)
+      );
+      if (visible.length > 0) launch(visible[0], openInTab);
+    });
   }
 
   const addBtn = $("addBtn");
@@ -382,11 +838,14 @@ function wireToolbar() {
   }
 
   const auditBtn = $("auditBtn");
-  if (auditBtn) auditBtn.addEventListener("click", () => toast(auditSummary()));
+  if (auditBtn) auditBtn.addEventListener("click", toggleAuditPanel);
 
   // Esc closes the form; "/" focuses search (but not while typing in a field).
   document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape") closeForm();
+    if (e.key === "Escape") {
+      closeForm();
+      closeAuditPanel();
+    }
     if (e.key === "/" && !isEditable(document.activeElement)) {
       e.preventDefault();
       if (search) search.focus();
@@ -409,6 +868,7 @@ function applyTheme(theme) {
 // ── rendering ────────────────────────────────────────────────────────────────
 
 function render() {
+  closeCardMenu(); // rebuilding the list would otherwise orphan an open menu's anchor button
   const list = $("credentialList");
   const empty = $("emptyState");
   if (!list) return;
@@ -437,6 +897,10 @@ function render() {
   visible.forEach((credential) => {
     list.appendChild(buildCard(credential));
   });
+  // Fresh chips start with an empty code — updateTotpChips() only runs on the
+  // 1s interval otherwise, so without this the code is blank for up to a
+  // second after every render (unlock, search, add/edit).
+  updateTotpChips();
 }
 
 function updateCount(visibleCount) {
@@ -453,7 +917,7 @@ function updateCount(visibleCount) {
 }
 
 // Security health shield in the header: green when clean, amber with a count when
-// there are reused passwords or orgs without 2FA. Click for a plain-language summary.
+// there are reused passwords or orgs without 2FA. Click opens the audit panel.
 function updateAudit() {
   const btn = $("auditBtn");
   if (!btn) return;
@@ -461,27 +925,139 @@ function updateAudit() {
     btn.hidden = true;
     return;
   }
-  const a = SFFav.auditCredentials(state.credentials);
+  const a = SFFav.auditCredentials(state.credentials, Date.now());
   btn.hidden = false;
   btn.classList.toggle("audit-warn", a.issues > 0);
   btn.title = a.issues > 0 ? `${a.issues} security issue(s)` : "No security issues";
   btn.innerHTML =
     svgMarkup("shield", a.issues === 0) +
     (a.issues > 0 ? `<span class="audit-badge">${a.issues}</span>` : "");
+  // Keep an already-open panel in sync (e.g. after "Set up 2FA" resolves).
+  if (!$("auditPanel").hidden) renderAuditPanel();
 }
 
-function auditSummary() {
-  const a = SFFav.auditCredentials(state.credentials);
-  if (a.issues === 0) return "Looks good — no reused passwords and 2FA on every org.";
-  const parts = [];
-  if (a.reusedGroups.length) {
-    const orgs = a.reusedGroups.reduce((n, g) => n + g.length, 0);
-    parts.push(`${orgs} orgs reuse a password`);
+function findCredentialByName(name) {
+  return state.credentials.find((c) => c.credentialName === name) || null;
+}
+
+function toggleAuditPanel() {
+  const panel = $("auditPanel");
+  if (!panel) return;
+  if (panel.hidden) openAuditPanel();
+  else closeAuditPanel();
+}
+
+function openAuditPanel() {
+  closeForm(); // the Add/Edit form and the audit panel don't need to coexist
+  const panel = $("auditPanel");
+  if (!panel) return;
+  panel.hidden = false;
+  renderAuditPanel();
+}
+
+function closeAuditPanel() {
+  const panel = $("auditPanel");
+  if (!panel) return;
+  panel.innerHTML = "";
+  panel.hidden = true;
+}
+
+// One row: the org name (click → jump to Edit) plus an optional action button.
+function auditRow(name, actionLabel, onAction) {
+  const row = document.createElement("div");
+  row.className = "audit-row";
+  const nameBtn = document.createElement("button");
+  nameBtn.type = "button";
+  nameBtn.className = "audit-row-name";
+  nameBtn.textContent = name;
+  nameBtn.title = "Edit this org";
+  nameBtn.addEventListener("click", () => {
+    const cred = findCredentialByName(name);
+    if (cred) {
+      closeAuditPanel();
+      openForm(indexOf(cred));
+    }
+  });
+  row.appendChild(nameBtn);
+  if (actionLabel) {
+    const actionBtn = document.createElement("button");
+    actionBtn.type = "button";
+    actionBtn.className = "btn audit-row-action";
+    actionBtn.textContent = actionLabel;
+    actionBtn.addEventListener("click", () => {
+      const cred = findCredentialByName(name);
+      if (cred) onAction(cred);
+    });
+    row.appendChild(actionBtn);
   }
-  if (a.noTwoFactor.length) {
-    parts.push(`${a.noTwoFactor.length} org${a.noTwoFactor.length === 1 ? "" : "s"} without 2FA`);
+  return row;
+}
+
+function auditSection(title, names, actionLabel, onAction) {
+  if (!names.length) return null;
+  const section = document.createElement("div");
+  section.className = "audit-section";
+  const heading = document.createElement("h3");
+  heading.textContent = `${title} (${names.length})`;
+  section.appendChild(heading);
+  names.forEach((name) => section.appendChild(auditRow(name, actionLabel, onAction)));
+  return section;
+}
+
+function renderAuditPanel() {
+  const panel = $("auditPanel");
+  if (!panel) return;
+  const a = SFFav.auditCredentials(state.credentials, Date.now());
+
+  panel.textContent = "";
+  const card = document.createElement("div");
+  card.className = "cred-form audit-card";
+
+  const head = document.createElement("div");
+  head.className = "form-head";
+  const title = document.createElement("strong");
+  title.textContent = "Security Audit";
+  const closeBtn = document.createElement("button");
+  closeBtn.type = "button";
+  closeBtn.className = "icon-btn";
+  closeBtn.setAttribute("aria-label", "Close");
+  closeBtn.innerHTML = svgMarkup("close");
+  closeBtn.addEventListener("click", closeAuditPanel);
+  head.appendChild(title);
+  head.appendChild(closeBtn);
+  card.appendChild(head);
+
+  if (a.issues === 0 && a.stale.length === 0) {
+    const clean = document.createElement("p");
+    clean.className = "audit-clean";
+    clean.textContent = "✓ Looks good — no reused passwords, 2FA on every org, and nothing stale.";
+    card.appendChild(clean);
+  } else {
+    // Each reused-password group gets its own section, since "fixing" one
+    // means changing that specific shared password across those specific orgs.
+    a.reusedGroups.forEach((names, i) => {
+      const section = auditSection(
+        a.reusedGroups.length > 1 ? `Reused password (group ${i + 1})` : "Reused password",
+        names,
+        null,
+        null
+      );
+      if (section) card.appendChild(section);
+    });
+    const noTwoFactorSection = auditSection("Missing 2FA", a.noTwoFactor, "Set up 2FA", (cred) => {
+      closeAuditPanel();
+      sendSetupTotp(cred);
+    });
+    if (noTwoFactorSection) card.appendChild(noTwoFactorSection);
+
+    const staleSection = auditSection("Not used in 90+ days", a.stale, null, null);
+    if (staleSection) {
+      staleSection.classList.add("audit-informational");
+      card.appendChild(staleSection);
+    }
   }
-  return parts.join(" · ");
+
+  panel.appendChild(card);
 }
 
 // Build one credential card. Credential-derived text uses textContent only.
@@ -514,6 +1090,22 @@ function buildCard(credential) {
   name.className = "cred-name";
   name.textContent = credential.credentialName; // untrusted → textContent
   nameRow.appendChild(name);
+
+  // Quick copy-username / copy-password affordances that fade in on card hover
+  // (see .cred-copy). SSO orgs have no username/password, so they get none —
+  // matching the overflow-menu guard. Icons mirror the menu (user / lock).
+  if (credential.environment !== "sso") {
+    const copyWrap = document.createElement("span");
+    copyWrap.className = "cred-copy";
+    const copyBtn = (icon, label, value, okMsg) =>
+      iconButton(icon, label, "cred-copy-btn", (e) => {
+        e.stopPropagation(); // don't trip any card-level handler
+        copy(value, okMsg);
+      });
+    copyWrap.appendChild(copyBtn("user", "Copy username", credential.username, "Username copied"));
+    copyWrap.appendChild(copyBtn("lock", "Copy password", credential.password, "Password copied"));
+    nameRow.appendChild(copyWrap);
+  }
 
   body.appendChild(nameRow);
 
@@ -571,21 +1163,45 @@ function buildCard(credential) {
   actions.appendChild(
     iconButton("tab", "Open in new tab", "", () => launch(credential, openInTab))
   );
-  actions.appendChild(
-    iconButton("window", "Open in new window", "", () => launch(credential, openInWindow))
-  );
-  actions.appendChild(
-    iconButton("incognito", "Open in incognito", "", () => launch(credential, openIncognito))
-  );
 
+  // Less-frequent actions live behind "more" instead of as permanent icons.
+  const menuItems = [
+    {
+      label: "Open in new window",
+      icon: "window",
+      onClick: () => launch(credential, openInWindow),
+    },
+    {
+      label: "Open in incognito",
+      icon: "incognito",
+      onClick: () => launch(credential, openIncognito),
+    },
+  ];
   if (credential.environment !== "sso") {
-    actions.appendChild(
-      iconButton("user", "Copy username", "", () => copy(credential.username, "Username copied"))
-    );
-    actions.appendChild(
-      iconButton("lock", "Copy password", "", () => copy(credential.password, "Password copied"))
+    menuItems.push(
+      {
+        label: "Copy username",
+        icon: "user",
+        onClick: () => copy(credential.username, "Username copied"),
+      },
+      {
+        label: "Copy password",
+        icon: "lock",
+        onClick: () => copy(credential.password, "Password copied"),
+      }
     );
   }
+  menuItems.push(
+    credential.totp
+      ? {
+          label: "Remove 2FA key",
+          icon: "shield-off",
+          danger: true,
+          onClick: () => removeTotp(credential),
+        }
+      : { label: "Set up 2FA", icon: "shield", onClick: () => sendSetupTotp(credential) }
+  );
+  actions.appendChild(iconMenuButton(menuItems));
 
   actions.appendChild(
     iconButton(
@@ -613,6 +1229,91 @@ function iconButton(name, title, extraClass, onClick, fill) {
   return btn;
 }
 
+// ── card overflow menu ───────────────────────────────────────────────────────
+// Less-frequent per-card actions live behind a "more" button instead of as
+// permanent icons, so a card isn't 9 icons wide. Rendered into #cardMenuPortal
+// (a fixed top-level container) rather than as a card child, since .cred-card
+// has overflow:hidden (for the colored rail) and would clip a dropdown.
+let openCardMenuBtn = null;
+
+function closeCardMenu() {
+  const portal = $("cardMenuPortal");
+  if (portal) portal.textContent = "";
+  openCardMenuBtn = null;
+}
+
+function openCardMenu(anchorBtn, items) {
+  const alreadyOpenForThisButton = openCardMenuBtn === anchorBtn;
+  closeCardMenu();
+  if (alreadyOpenForThisButton) return; // clicking the same button again just closes it
+
+  const portal = $("cardMenuPortal");
+  if (!portal) return;
+  const list = document.createElement("div");
+  list.className = "card-menu-list";
+  items.forEach(({ label, icon, onClick, danger }) => {
+    const item = document.createElement("button");
+    item.type = "button";
+    item.className = `card-menu-item ${danger ? "danger" : ""}`.trim();
+    const iconSpan = document.createElement("span");
+    iconSpan.className = "card-menu-icon";
+    iconSpan.innerHTML = svgMarkup(icon);
+    const labelSpan = document.createElement("span");
+    labelSpan.textContent = label;
+    item.appendChild(iconSpan);
+    item.appendChild(labelSpan);
+    item.addEventListener("click", () => {
+      closeCardMenu();
+      onClick();
+    });
+    list.appendChild(item);
+  });
+  portal.appendChild(list);
+
+  // Position from the button's actual screen coordinates (the portal has no
+  // layout relationship to the card), keeping the menu on-screen horizontally.
+  const rect = anchorBtn.getBoundingClientRect();
+  const menuWidth = list.offsetWidth || 180;
+  list.style.top = `${rect.bottom + 4}px`;
+  list.style.left = `${Math.max(8, rect.right - menuWidth)}px`;
+  openCardMenuBtn = anchorBtn;
+}
+
+function iconMenuButton(items) {
+  const btn = document.createElement("button");
+  btn.className = "icon-btn";
+  btn.title = "More actions";
+  btn.setAttribute("aria-label", "More actions");
+  btn.innerHTML = svgMarkup("more", true);
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    openCardMenu(btn, items);
+  });
+  return btn;
+}
+
+// Close on outside click, Escape, or scrolling the list (a fixed-position
+// menu would otherwise visually detach from its anchor as the list scrolls).
+document.addEventListener("click", (e) => {
+  if (
+    openCardMenuBtn &&
+    !e.target.closest(".card-menu-list") &&
+    !openCardMenuBtn.contains(e.target)
+  ) {
+    closeCardMenu();
+  }
+});
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape") closeCardMenu();
+});
+document.addEventListener(
+  "scroll",
+  (e) => {
+    if (openCardMenuBtn && e.target.contains && e.target.contains(openCardMenuBtn)) closeCardMenu();
+  },
+  true
+);
+
 function indexOf(credential) {
   return state.credentials.indexOf(credential);
 }
@@ -635,6 +1336,26 @@ function togglePin(credential) {
   state.credentials = SFFav.togglePinAt(state.credentials, idx);
   persist();
   render();
+}
+
+// Clears a stored 2FA key so "Set up 2FA" reappears — for a key that was
+// generated but never actually registered with Salesforce (or the phone),
+// which otherwise can't be cleared since the Add/Edit form no longer has a
+// totp field (2FA setup lives in the post-login flow instead).
+function removeTotp(credential) {
+  const idx = indexOf(credential);
+  if (idx === -1) return;
+  const ok = confirm(
+    `Remove the saved 2FA key for "${credential.credentialName}"?\n\n` +
+      "Only do this if it was never actually registered with Salesforce or your phone " +
+      "— otherwise you'll lose the ability to generate matching codes. " +
+      '"Set up 2FA" will be available again afterward.'
+  );
+  if (!ok) return;
+  state.credentials[idx] = { ...state.credentials[idx], totp: "" };
+  persist();
+  render();
+  toast("2FA key removed");
 }
 
 function removeCard(credential) {
@@ -723,7 +1444,13 @@ function toast(message) {
 
 // ── add / edit form ──────────────────────────────────────────────────────────
 
+// Live-code refresh timer for the form's 2FA enrollment preview. Held at module
+// scope so closeForm() can stop it (leaving it running would keep computing
+// codes for a closed form). null when no form is open.
+let formTotpTimer = null;
+
 function openForm(editIndex) {
+  closeAuditPanel(); // the audit panel and the Add/Edit form don't need to coexist
   state.editIndex = typeof editIndex === "number" && editIndex >= 0 ? editIndex : null;
   const container = $("formContainer");
   if (!container) return;
@@ -749,68 +1476,21 @@ function openForm(editIndex) {
     });
   }
 
-  // Authenticator (2FA): SalesForceFav can be its own authenticator — "New"
-  // generates a fresh Base32 secret; the setup row reveals the key + an
-  // otpauth:// link to register the same secret with Salesforce or a phone.
-  const totp = $("totp");
-  const totpSetup = $("totpSetup");
-  const totpSetupKey = $("totpSetupKey");
-  const totpQr = $("totpQr");
-  // Build the otpauth:// URI for the current secret (account = username/name).
-  const currentOtpauthUri = () =>
-    SFFav.buildOtpauthUri({
-      account: $("username").value.trim() || $("credentialName").value.trim() || "account",
-      secret: totp.value.trim(),
-    });
-  const showTotpSetup = () => {
-    const secret = totp.value.trim();
-    const valid = secret && SFFav.isValidTotpSecret(secret);
-    // Show the key + QR setup only once a valid Base32 key is present.
-    if (!valid) {
-      totpSetup.hidden = true;
-      totpQr.innerHTML = "";
-      return;
-    }
-    totpSetupKey.textContent = secret.replace(/(.{4})/g, "$1 ").trim();
-    // Render the QR locally (the secret never leaves the browser). The SVG is
-    // built from static rects by the vendored encoder — safe to inject.
-    try {
-      const qr = qrcode(0, "M"); // type 0 = auto-size, error-correction level M
-      qr.addData(currentOtpauthUri());
-      qr.make();
-      totpQr.innerHTML = qr.createSvgTag({ cellSize: 4, margin: 2, scalable: true });
-    } catch (e) {
-      totpQr.innerHTML = "";
-      console.error("QR render failed:", e);
-    }
-    totpSetup.hidden = false;
-  };
-  totp.addEventListener("input", showTotpSetup);
-  $("totpCopyKey").addEventListener("click", () => copy(totp.value.trim(), "Key copied"));
-  $("totpCopyUri").addEventListener("click", () => copy(currentOtpauthUri(), "Setup link copied"));
-
   // Populate when editing (values set via .value — not innerHTML).
   if (cred) {
     $("title").textContent = "Edit org";
     $("credentialName").value = cred.credentialName || "";
     environment.value = cred.environment || "";
     $("ssourl").value = cred.ssourl || "";
+    $("customurl").value = cred.customurl || "";
     $("username").value = cred.username || "";
     $("password").value = cred.password || "";
     $("faviconColor").value = cred.faviconColor || SFFav.DEFAULT_FAVICON_COLOR;
-    $("totp").value = cred.totp || "";
-    showTotpSetup();
     $("pinned").checked = cred.pinned === true;
-  } else {
-    // New org: generate an authenticator key so the 2FA QR is visible by default
-    // (no "New" button). Scan it into Salesforce, paste your own key to override,
-    // or clear the field for no 2FA.
-    const bytes = new Uint8Array(20); // 160-bit secret (RFC 6238 §5.1)
-    crypto.getRandomValues(bytes);
-    $("totp").value = SFFav.base32Encode(bytes);
-    showTotpSetup();
+    $("totp").value = cred.totp || "";
   }
   updateEnvFields(environment.value);
+  wireFormTotp();
 
   $("newCredentialForm").addEventListener("submit", onFormSubmit);
   const cancel = (e) => {
@@ -823,14 +1503,90 @@ function openForm(editIndex) {
   $("credentialName").focus();
 }
 
+// Wire the in-form 2FA authenticator: Generate a key, live-preview the QR +
+// rolling code as the user types, and copy the otpauth setup link. The key is a
+// normal form field — onFormSubmit persists it like any other, and the card's
+// live chip (updateTotpChips) takes over once saved.
+function wireFormTotp() {
+  const input = $("totp");
+  if (!input) return;
+
+  $("totpGenerate").addEventListener("click", () => {
+    // 160-bit secret (RFC 6238 §5.1), Base32 like an authenticator app prints.
+    input.value = SFFav.base32Encode(crypto.getRandomValues(new Uint8Array(20)));
+    refreshFormTotp();
+    input.focus();
+  });
+  input.addEventListener("input", refreshFormTotp);
+
+  $("totpCopyUri").addEventListener("click", () => {
+    const uri = formOtpauthUri();
+    if (uri) copy(uri, "Setup link copied");
+  });
+
+  refreshFormTotp();
+  // Roll the live preview once a second while the form is open.
+  if (formTotpTimer) clearInterval(formTotpTimer);
+  formTotpTimer = setInterval(updateFormTotpLive, 1000);
+}
+
+// The otpauth:// URI for the key currently in the form, or null if it isn't a
+// valid Base32 secret yet. Account label prefers the username, then the org name.
+function formOtpauthUri() {
+  const secret = $("totp").value.trim();
+  if (!SFFav.isValidTotpSecret(secret)) return null;
+  const account = $("username").value.trim() || $("credentialName").value.trim() || "account";
+  return SFFav.buildOtpauthUri({ account, secret });
+}
+
+// Show/hide the enrollment block based on key validity and (re)render the QR.
+function refreshFormTotp() {
+  const enroll = $("totpEnroll");
+  const uri = formOtpauthUri();
+  if (!uri) {
+    enroll.hidden = true;
+    return;
+  }
+  enroll.hidden = false;
+  const host = $("totpQr");
+  try {
+    const qr = qrcode(0, "Q"); // type 0 = auto-size; level Q tolerates screen glare
+    qr.addData(uri);
+    qr.make();
+    host.innerHTML = qr.createSvgTag({ cellSize: 4, margin: 2, scalable: true });
+  } catch {
+    host.textContent = "QR unavailable — use the key above.";
+  }
+  updateFormTotpLive();
+}
+
+// Refresh the form's live code + countdown (mirrors updateTotpChips for the card).
+function updateFormTotpLive() {
+  const codeEl = $("totpLiveCode");
+  const leftEl = $("totpLiveLeft");
+  if (!codeEl || !leftEl) return;
+  const secret = $("totp").value.trim();
+  if (!SFFav.isValidTotpSecret(secret)) return;
+  const now = Date.now() / 1000;
+  const code = SFFav.totp(secret, now);
+  const left = SFFav.totpSecondsRemaining(now);
+  if (code) codeEl.textContent = `${code.slice(0, 3)} ${code.slice(3)}`;
+  leftEl.textContent = `${left}s`;
+}
+
 function updateEnvFields(value) {
   const sso = value === "sso";
+  const custom = value === "custom";
   $("ssoUrlFieldContainer").hidden = !sso;
+  $("customUrlFieldContainer").hidden = !custom;
   $("usernameFieldContainer").hidden = sso;
   $("passwordFieldContainer").hidden = sso;
+  // TOTP is meaningless for SSO (no password to protect; MFA lives at the IdP).
+  $("totpFieldContainer").hidden = sso;
   $("username").required = !sso;
   $("password").required = !sso;
   $("ssourl").required = sso;
+  $("customurl").required = custom;
 }
 
 function onFormSubmit(event) {
@@ -847,10 +1603,14 @@ function onFormSubmit(event) {
     credentialName: $("credentialName").value.trim(),
     environment,
     ssourl: isSSO ? $("ssourl").value.trim() : "",
+    customurl: environment === "custom" ? $("customurl").value.trim() : "",
     username: isSSO ? "" : $("username").value.trim(),
     password: isSSO ? "" : $("password").value,
     faviconColor: $("faviconColor").value,
-    totp: $("totp").value.trim(),
+    // 2FA key entered in the form (also settable via the post-login QR flow in
+    // background.js). Cleared for SSO. validateCredential rejects a present-but-
+    // invalid Base32 key, so no extra check is needed here.
+    totp: isSSO ? "" : $("totp").value.trim(),
     pinned: $("pinned").checked,
     lastUsedAt: (editing && editing.lastUsedAt) || null,
   };
@@ -875,6 +1635,10 @@ function onFormSubmit(event) {
 function closeForm() {
   const container = $("formContainer");
   if (!container) return;
+  if (formTotpTimer) {
+    clearInterval(formTotpTimer);
+    formTotpTimer = null;
+  }
   container.innerHTML = "";
   container.hidden = true;
   state.editIndex = null;
@@ -915,12 +1679,18 @@ const formHtml = `
       <option value="" disabled selected>Select environment</option>
       <option value="sandbox">Sandbox</option>
       <option value="production">Production</option>
+      <option value="custom">Custom domain (My Domain)</option>
       <option value="sso">SSO</option>
     </select>
 
     <div id="ssoUrlFieldContainer" hidden>
       <label for="ssourl">SSO URL</label>
       <input type="url" id="ssourl" placeholder="https://my.okta.com/…" />
+    </div>
+
+    <div id="customUrlFieldContainer" hidden>
+      <label for="customurl">My Domain login URL</label>
+      <input type="url" id="customurl" placeholder="https://acme.my.salesforce.com" />
     </div>
 
     <div id="usernameFieldContainer">
@@ -936,23 +1706,28 @@ const formHtml = `
       </div>
     </div>
 
-    <label for="totp">Authenticator key (2FA) — optional</label>
-    <input type="text" id="totp" autocomplete="off" placeholder="Base32 secret from your authenticator" />
-    <div id="totpSetup" class="totp-setup" hidden>
-      <p class="totp-setup-title">Scan to add this org's 2FA</p>
-      <p class="totp-setup-hint">
-        Scan this into Salesforce (or your phone) to enable 2FA — or paste your own key
-        above. Clear the field for no 2FA.
-      </p>
-      <div id="totpQr" class="totp-qr" aria-label="2FA setup QR code"></div>
-      <div class="totp-setup-keyrow">
-        <code id="totpSetupKey" class="totp-setup-key"></code>
+    <div id="totpFieldContainer">
+      <label for="totp">2FA / Authenticator key <span class="field-opt">(optional)</span></label>
+      <div class="totp-input-row">
+        <input type="text" id="totp" placeholder="Base32 key (e.g. JBSW Y3DP …)" autocomplete="off" spellcheck="false" />
+        <button type="button" id="totpGenerate" class="btn">Generate</button>
       </div>
-      <div class="totp-setup-actions">
-        <button type="button" id="totpCopyKey" class="btn">Copy key</button>
-        <button type="button" id="totpCopyUri" class="btn">Copy setup link</button>
+      <div id="totpEnroll" class="totp-enroll" hidden>
+        <div id="totpQr" class="totp-qr" aria-hidden="true"></div>
+        <div class="totp-enroll-side">
+          <div class="totp-live">
+            <span id="totpLiveCode" class="totp-live-code">— — —</span>
+            <span id="totpLiveLeft" class="totp-live-left"></span>
+          </div>
+          <button type="button" id="totpCopyUri" class="btn btn-small">Copy setup link</button>
+          <p class="totp-hint">
+            Scan in Salesforce (Setup → Advanced User Details → App Registration:
+            Authenticator Apps), or paste this key there.
+          </p>
+        </div>
       </div>
     </div>
+
 
     <div class="form-row">
       <label for="faviconColor">Tab color</label>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -165,6 +165,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   wireLock();
   await initStore();
   probePlatformAuth(); // async; re-renders the biometric affordances when it resolves
+  probeCli(); // async; reveals/hides the built-in authenticator once we know if the CLI is installed
   updateLockButton();
   updateDeviceUnlockButton();
   if (isEncrypted()) {
@@ -351,6 +352,50 @@ async function probePlatformAuth() {
 }
 const deviceUnlockSupported = () => platformAuthAvailable;
 const hasDeviceUnlock = () => storeGet(DEVICE_UNLOCK_KEY) !== null;
+
+// ── CLI presence (gates the built-in authenticator) ──────────────────────────
+// The extension can't see a globally-installed binary directly, so the sffav
+// CLI registers a native-messaging host (`sffav install-host`) and we ping it.
+// A reply means the CLI is present → the in-popup 2FA authenticator is offered;
+// no host (or no reply) → it's hidden behind an "install the CLI" hint. Probed
+// once at startup and cached, then the 2FA surfaces re-render.
+const NATIVE_HOST = "com.salesforcefav.host";
+let cliInstalled = false;
+async function probeCli() {
+  cliInstalled = await new Promise((resolve) => {
+    let settled = false;
+    const done = (v) => {
+      if (!settled) {
+        settled = true;
+        resolve(v);
+      }
+    };
+    // A host that connects but never answers shouldn't hang the gate forever.
+    const timer = setTimeout(() => done(false), 2000);
+    try {
+      chrome.runtime.sendNativeMessage(NATIVE_HOST, { type: "ping" }, (resp) => {
+        clearTimeout(timer);
+        // lastError fires when no host is registered — the "not installed" case.
+        done(!chrome.runtime.lastError && !!(resp && resp.ok));
+      });
+    } catch {
+      clearTimeout(timer);
+      done(false);
+    }
+  });
+  applyFormCliGate(); // update an open Add/Edit form
+  render(); // re-render cards (2FA chip + "Set up 2FA" menu gate)
+}
+
+// Show the built-in-authenticator controls only when the CLI is present;
+// otherwise show the "install the CLI" hint. No-op when no form is open.
+function applyFormCliGate() {
+  const controls = $("totpControls");
+  const hint = $("totpCliHint");
+  if (!controls || !hint) return;
+  controls.hidden = !cliInstalled;
+  hint.hidden = cliInstalled;
+}
 
 function bytesToB64(bytes) {
   let s = "";
@@ -1044,10 +1089,17 @@ function renderAuditPanel() {
       );
       if (section) card.appendChild(section);
     });
-    const noTwoFactorSection = auditSection("Missing 2FA", a.noTwoFactor, "Set up 2FA", (cred) => {
-      closeAuditPanel();
-      sendSetupTotp(cred);
-    });
+    // The "Set up 2FA" action is part of the built-in authenticator, so it's
+    // offered only when the CLI is installed; the list itself still shows.
+    const noTwoFactorSection = auditSection(
+      "Missing 2FA",
+      a.noTwoFactor,
+      cliInstalled ? "Set up 2FA" : null,
+      (cred) => {
+        closeAuditPanel();
+        sendSetupTotp(cred);
+      }
+    );
     if (noTwoFactorSection) card.appendChild(noTwoFactorSection);
 
     const staleSection = auditSection("Not used in 90+ days", a.stale, null, null);
@@ -1130,10 +1182,11 @@ function buildCard(credential) {
 
   body.appendChild(meta);
 
-  // Live 2FA code chip (only when an authenticator key is stored). The secret is
+  // Live 2FA code chip — part of the built-in authenticator, so it's shown only
+  // when the CLI is installed (see probeCli) and a key is stored. The secret is
   // attached as a JS property — never as a DOM attribute — so it isn't exposed in
   // the serialized HTML. updateTotpChips() refreshes the code/countdown each tick.
-  if (credential.totp && SFFav.isValidTotpSecret(credential.totp)) {
+  if (cliInstalled && credential.totp && SFFav.isValidTotpSecret(credential.totp)) {
     const chip = document.createElement("button");
     chip.className = "totp-chip";
     chip.type = "button";
@@ -1191,16 +1244,23 @@ function buildCard(credential) {
       }
     );
   }
-  menuItems.push(
-    credential.totp
-      ? {
-          label: "Remove 2FA key",
-          icon: "shield-off",
-          danger: true,
-          onClick: () => removeTotp(credential),
-        }
-      : { label: "Set up 2FA", icon: "shield", onClick: () => sendSetupTotp(credential) }
-  );
+  // 2FA menu entries are part of the built-in authenticator — only when the CLI
+  // is installed. "Remove 2FA key" stays available so a key saved earlier (or via
+  // the CLI) can always be cleared, even if the CLI was since removed.
+  if (credential.totp) {
+    menuItems.push({
+      label: "Remove 2FA key",
+      icon: "shield-off",
+      danger: true,
+      onClick: () => removeTotp(credential),
+    });
+  } else if (cliInstalled) {
+    menuItems.push({
+      label: "Set up 2FA",
+      icon: "shield",
+      onClick: () => sendSetupTotp(credential),
+    });
+  }
   actions.appendChild(iconMenuButton(menuItems));
 
   actions.appendChild(
@@ -1491,6 +1551,7 @@ function openForm(editIndex) {
   }
   updateEnvFields(environment.value);
   wireFormTotp();
+  applyFormCliGate(); // built-in authenticator only when the CLI is installed
 
   $("newCredentialForm").addEventListener("submit", onFormSubmit);
   const cancel = (e) => {
@@ -1707,23 +1768,31 @@ const formHtml = `
     </div>
 
     <div id="totpFieldContainer">
-      <label for="totp">2FA / Authenticator key <span class="field-opt">(optional)</span></label>
-      <div class="totp-input-row">
-        <input type="text" id="totp" placeholder="Base32 key (e.g. JBSW Y3DP …)" autocomplete="off" spellcheck="false" />
-        <button type="button" id="totpGenerate" class="btn">Generate</button>
+      <!-- Built-in authenticator: shown only when the sffav CLI is installed
+           (detected via native messaging — see probeCli). Otherwise the hint. -->
+      <div id="totpCliHint" class="totp-cli-hint" hidden>
+        <strong>Built-in authenticator</strong> needs the <code>sffav</code> CLI. Install it, run
+        <code>sffav install-host</code>, then reopen this popup.
       </div>
-      <div id="totpEnroll" class="totp-enroll" hidden>
-        <div id="totpQr" class="totp-qr" aria-hidden="true"></div>
-        <div class="totp-enroll-side">
-          <div class="totp-live">
-            <span id="totpLiveCode" class="totp-live-code">— — —</span>
-            <span id="totpLiveLeft" class="totp-live-left"></span>
+      <div id="totpControls" hidden>
+        <label for="totp">2FA / Authenticator key <span class="field-opt">(optional)</span></label>
+        <div class="totp-input-row">
+          <input type="text" id="totp" placeholder="Base32 key (e.g. JBSW Y3DP …)" autocomplete="off" spellcheck="false" />
+          <button type="button" id="totpGenerate" class="btn">Generate</button>
+        </div>
+        <div id="totpEnroll" class="totp-enroll" hidden>
+          <div id="totpQr" class="totp-qr" aria-hidden="true"></div>
+          <div class="totp-enroll-side">
+            <div class="totp-live">
+              <span id="totpLiveCode" class="totp-live-code">— — —</span>
+              <span id="totpLiveLeft" class="totp-live-left"></span>
+            </div>
+            <button type="button" id="totpCopyUri" class="btn btn-small">Copy setup link</button>
+            <p class="totp-hint">
+              Scan in Salesforce (Setup → Advanced User Details → App Registration:
+              Authenticator Apps), or paste this key there.
+            </p>
           </div>
-          <button type="button" id="totpCopyUri" class="btn btn-small">Copy setup link</button>
-          <p class="totp-hint">
-            Scan in Salesforce (Setup → Advanced User Details → App Registration:
-            Authenticator Apps), or paste this key there.
-          </p>
         </div>
       </div>
     </div>

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,0 +1,72 @@
+// Integration test: the sffav CLI is a REAL RFC-6238 authenticator, not a stub.
+//
+// It drives the actual CLI binary (child process) against a throwaway encrypted
+// vault and asserts the code it prints matches what the unit-tested library
+// (popup/credentials.js) computes for the same secret and time. This is the
+// "it should be real 2FA" proof: same algorithm, end to end, through the vault.
+
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const SFFav = require("../popup/credentials.js");
+
+const CLI = path.resolve(__dirname, "..", "cli", "sffav.cjs");
+const PASS = "test-pass-123";
+const SECRET = "JBSWY3DPEHPK3PXP"; // valid Base32 authenticator key
+
+// Run the CLI with the passphrase supplied via env (no interactive prompt) and
+// an explicit throwaway vault path.
+function run(args, vault) {
+  return execFileSync("node", [CLI, ...args, "--vault", vault], {
+    env: { ...process.env, SFFAV_PASSPHRASE: PASS },
+    encoding: "utf8",
+  });
+}
+
+describe("sffav CLI — real TOTP authenticator", () => {
+  let dir;
+  let vault;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "sffav-cli-"));
+    vault = path.join(dir, "vault.json");
+    run(["init"], vault);
+    run(
+      ["add", "--name", "Prod", "--env", "production", "--username", "u@x.com", "--password", "p"],
+      vault
+    );
+    run(["totp", "Prod", "--set", SECRET], vault);
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("--raw prints a 6-digit code that matches the library algorithm", () => {
+    const raw = run(["totp", "Prod", "--raw"], vault).trim();
+    expect(raw).toMatch(/^\d{6}$/);
+    // Accept the adjacent windows too, so a 30s boundary crossing mid-exec
+    // (library computed, then the CLI process runs) can't flake the test.
+    const now = Date.now() / 1000;
+    const acceptable = new Set([
+      SFFav.totp(SECRET, now - 1),
+      SFFav.totp(SECRET, now),
+      SFFav.totp(SECRET, now + 1),
+    ]);
+    expect(acceptable.has(raw)).toBe(true);
+  });
+
+  test("--uri emits a scannable otpauth URI carrying the stored secret", () => {
+    const uri = run(["totp", "Prod", "--uri"], vault).trim();
+    expect(uri).toMatch(/^otpauth:\/\/totp\//);
+    expect(uri).toContain(`secret=${SECRET}`);
+    expect(uri).toContain("period=30");
+  });
+
+  test("the key is stored ENCRYPTED — the secret never appears in the vault file", () => {
+    const onDisk = fs.readFileSync(vault, "utf8");
+    expect(onDisk).not.toContain(SECRET);
+    expect(onDisk).not.toContain("u@x.com");
+  });
+});

--- a/tests/credentials.test.js
+++ b/tests/credentials.test.js
@@ -45,6 +45,13 @@ describe("resolveSalesforceUrl", () => {
     expect(resolveSalesforceUrl({ environment: "nope" })).toBeNull();
     expect(resolveSalesforceUrl(null)).toBeNull();
   });
+
+  test("uses the supplied My Domain URL for custom, null when missing", () => {
+    expect(
+      resolveSalesforceUrl({ environment: "custom", customurl: "https://acme.my.salesforce.com" })
+    ).toBe("https://acme.my.salesforce.com");
+    expect(resolveSalesforceUrl({ environment: "custom" })).toBeNull();
+  });
 });
 
 describe("normalizeName", () => {
@@ -116,6 +123,26 @@ describe("validateCredential", () => {
     expect(valid).toBe(false);
     expect(errors.credentialName).toBeDefined();
     expect(errors.environment).toBeDefined();
+  });
+
+  test("custom environment requires a valid My Domain URL plus username/password", () => {
+    const base = { credentialName: "Acme", environment: "custom", username: "u", password: "p" };
+    expect(validateCredential({ ...base, customurl: "not a url" }, [], null).valid).toBe(false);
+    expect(
+      validateCredential({ ...base, customurl: "https://acme.my.salesforce.com" }, [], null).valid
+    ).toBe(true);
+    const missingCreds = validateCredential(
+      {
+        credentialName: "Acme",
+        environment: "custom",
+        customurl: "https://acme.my.salesforce.com",
+      },
+      [],
+      null
+    );
+    expect(missingCreds.valid).toBe(false);
+    expect(missingCreds.errors.username).toBeDefined();
+    expect(missingCreds.errors.password).toBeDefined();
   });
 
   test("flags duplicate names", () => {
@@ -332,6 +359,39 @@ describe("auditCredentials (security health)", () => {
 
   test("clean vault reports no issues", () => {
     expect(auditCredentials([]).issues).toBe(0);
+  });
+
+  test("flags orgs unused for 90+ days as stale, without affecting issues", () => {
+    const DAY = 24 * 60 * 60 * 1000;
+    const now = 1_700_000_000_000;
+    const { stale, issues } = auditCredentials(
+      [
+        {
+          credentialName: "Fresh",
+          environment: "production",
+          password: "unique1",
+          totp: "JBSWY3DPEHPK3PXP",
+          lastUsedAt: now - 10 * DAY,
+        },
+        {
+          credentialName: "Old",
+          environment: "sandbox",
+          password: "unique2",
+          totp: "JBSWY3DPEHPK3PXP",
+          lastUsedAt: now - 100 * DAY,
+        },
+        {
+          credentialName: "NeverUsed",
+          environment: "sandbox",
+          password: "unique3",
+          totp: "JBSWY3DPEHPK3PXP",
+          lastUsedAt: null,
+        },
+      ],
+      now
+    );
+    expect(stale).toEqual(["Old"]);
+    expect(issues).toBe(0); // staleness is informational, not a security issue
   });
 });
 

--- a/tests/native-host.test.js
+++ b/tests/native-host.test.js
@@ -1,0 +1,89 @@
+// The native-messaging host is what lets the extension detect that the CLI is
+// installed (which gates the in-popup built-in authenticator). These tests cover
+// both halves: the host answers a framed ping, and `sffav install-host` writes a
+// valid host manifest the browser can load.
+
+const { spawn, execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const HOST = path.resolve(__dirname, "..", "cli", "native-host.cjs");
+const CLI = path.resolve(__dirname, "..", "cli", "sffav.cjs");
+const HOST_NAME = "com.salesforcefav.host";
+
+// Chrome native-messaging framing: 4-byte little-endian length prefix + JSON.
+function frame(obj) {
+  const body = Buffer.from(JSON.stringify(obj), "utf8");
+  const header = Buffer.alloc(4);
+  header.writeUInt32LE(body.length, 0);
+  return Buffer.concat([header, body]);
+}
+
+function pingHost(message) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [HOST]);
+    let out = Buffer.alloc(0);
+    proc.stdout.on("data", (d) => {
+      out = Buffer.concat([out, d]);
+      if (out.length >= 4) {
+        const len = out.readUInt32LE(0);
+        if (out.length >= 4 + len) {
+          resolve(JSON.parse(out.subarray(4, 4 + len).toString("utf8")));
+          proc.stdin.end();
+        }
+      }
+    });
+    proc.on("error", reject);
+    proc.stdin.write(frame(message));
+  });
+}
+
+describe("native-messaging host", () => {
+  test("answers a framed ping with { ok: true } and the app version", async () => {
+    const reply = await pingHost({ type: "ping" });
+    expect(reply.ok).toBe(true);
+    expect(reply.host).toBe(HOST_NAME);
+    expect(reply.app).toBe("SalesForceFav");
+    expect(reply.echo).toBe("ping");
+  });
+});
+
+describe("sffav install-host", () => {
+  let dir;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "sffav-nm-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function run(args) {
+    return execFileSync("node", [CLI, ...args], {
+      env: { ...process.env, SFFAV_NM_DIR: dir },
+      encoding: "utf8",
+    });
+  }
+
+  test("writes a valid host manifest pointing at an existing host script", () => {
+    run(["install-host", "abcdefghijklmnopabcdefghijklmnop"]);
+    const manifest = JSON.parse(fs.readFileSync(path.join(dir, `${HOST_NAME}.json`), "utf8"));
+    expect(manifest.name).toBe(HOST_NAME);
+    expect(manifest.type).toBe("stdio");
+    expect(fs.existsSync(manifest.path)).toBe(true);
+    // Always includes the published Chrome id, plus the dev id we passed.
+    expect(manifest.allowed_origins).toContain(
+      "chrome-extension://abcdefghijklmnopabcdefghijklmnop/"
+    );
+    expect(manifest.allowed_origins.some((o) => /^chrome-extension:\/\/[a-p]{32}\/$/.test(o))).toBe(
+      true
+    );
+  });
+
+  test("uninstall-host removes the manifest", () => {
+    run(["install-host"]);
+    expect(fs.existsSync(path.join(dir, `${HOST_NAME}.json`))).toBe(true);
+    run(["uninstall-host"]);
+    expect(fs.existsSync(path.join(dir, `${HOST_NAME}.json`))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Completes the 2FA feature end-to-end, gates the built-in authenticator on the CLI, and closes several UX gaps.

### 2FA
- **In-popup authenticator** — the Add/Edit form has a 2FA key field: paste an existing Base32 secret or **Generate** a 160-bit one, with an inline **QR + otpauth "setup link"** to register with Salesforce and a **live rolling-code preview**. Enroll an org's TOTP without needing the post-login page. Loads the CSP-safe vendored `qrcode.js` on the popup.
- **Auto-submit on the login challenge** — `fillTotpCodeInPage` gains a `submit` flag that clicks the verify control; `handleLogin` waits past a 30s window boundary (if <5s remain) and submits a fresh code. Default stays fill-only.

### Built-in authenticator now requires the CLI (native messaging)
The in-popup 2FA authenticator is available **if and only if the `sffav` CLI is installed** — the CLI is the encrypted, testable source of truth for authenticator keys. A browser extension can't see a globally-installed binary, so the CLI registers a **native-messaging host** and the popup pings it to detect presence.

- **`cli/native-host.cjs`** — a minimal native-messaging host that answers a framed ping (`{ok:true,version}`); exposes no vault data, needs no passphrase (presence is the whole signal).
- **`sffav install-host [ext-id…]` / `uninstall-host`** — register/remove the host manifest in each installed browser's `NativeMessagingHosts` dir (macOS/Linux files; Windows registry). The published Chrome id is included by default; pass unpacked/dev ids as args. `SFFAV_NM_DIR` overrides the target (used by tests).
- **`manifest.json`** — adds the `nativeMessaging` permission.
- **`popup.js`** — `probeCli()` pings the host on open (2s guard, cached) and gates every built-in-authenticator surface: the form's 2FA section (shows an "install the CLI" hint otherwise), the card live-code chip, the "Set up 2FA" menu item, and the audit action. **"Remove 2FA key" stays available** so a saved key can always be cleared.

Enable it:
```bash
npm i -g .                              # install the CLI
sffav install-host                      # published build
sffav install-host <your-extension-id>  # …or an unpacked/dev id (chrome://extensions)
```

### UX
- **Hover-to-copy** — username/password copy icons fade in on each card (non-SSO), keyboard-accessible via `:focus-within`.
- **OS-aware biometric label** — shows only **"Touch ID"** on Apple / **"Windows Hello"** on Windows (never both; generic elsewhere), across the lock button, header toggle, toasts, and confirms. Remains an **OR alongside the master passphrase** — biometric is an alternative, never a replacement.
- **Stay-unlocked for the browser session** via `chrome.storage.session`, and a lock screen that surfaces biometric as the headline action only when it's enrolled **and** the platform actually supports it (`isUserVerifyingPlatformAuthenticatorAvailable`).

### CLI
- **`tests/cli.test.js`** proves the CLI is a real RFC-6238 authenticator: codes match the unit-tested library, `--uri` emits a scannable otpauth link, and the key is stored **encrypted** (never plaintext in the vault). README documents global install + the real-2FA guarantee.

Also includes prior working-tree work: custom **"My Domain"** environment, **stale-org audit**, **org-color tinting** that follows the tab, and **Login Discovery** multi-step fill.

## Test plan
- ✅ `npm test` — **70/70** pass (credentials, cryptovault, vault, CLI real-2FA, native-host handshake), eslint + prettier clean, `node --check` clean.
- ✅ Headless proofs: form logic (Generate → key → otpauth → 46 KB QR SVG → live code; RFC 6238 vector matches); CLI code matches the library; native host answers a framed ping; `install-host` writes a valid manifest.
- ⏳ Manual (Chrome blocks automating extension pages): `npm i -g . && sffav install-host <dev-id>`, reload unpacked → Add org shows the authenticator + QR + live code; remove the host → falls back to the "install the CLI" hint; hover a card shows copy icons; lock screen shows the OS-correct biometric label.

## Reviewer notes / risks
- **Behavior change for existing users:** anyone already using the in-popup 2FA loses that UI until they install the CLI **and** run `sffav install-host`. Intended ("iff installed"), but on a published extension it's a visible regression — needs a release note.
- **`nativeMessaging` is a new permission** — bumps the install prompt and triggers store re-review on Chrome and Edge.
- **Edge extension id** — only the Edge Partner-Center GUID is known (differs from the runtime id), so Edge users must pass their actual id: `sffav install-host <edge-id>`. The Chrome published id is baked in.
- **Auto-submit carries a real account-lockout risk** on a wrong/clock-skewed code — the >5s guard only covers window-boundary expiry. Can be gated behind an opt-in toggle if preferred.
- The `proto-sw-tmp.mjs` e2e prototype is intentionally **not** included (fails the eslint gate; to be folded into a proper `tests/e2e/launch.e2e.mjs` later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)