### PR TITLE
Side-by-side Touch ID / passphrase lock screen

### DIFF
--- a/popup/popup.css
+++ b/popup/popup.css
@@ -815,7 +815,7 @@ body.sff-locked #formContainer {
 }
 .lock-card {
   width: 100%;
-  max-width: 300px;
+  max-width: 324px;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -840,20 +840,57 @@ body.sff-locked #formContainer {
   line-height: 1.45;
   color: var(--text-muted);
 }
-.lock-submit {
+/* Side-by-side unlock methods: [ Touch ID ] or [ passphrase ]. */
+.lock-methods {
+  display: flex;
+  align-items: stretch; /* both columns share the taller column's height */
+  gap: 10px;
   width: 100%;
+}
+.lock-pass-col {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 6px;
 }
 .lock-pw {
   display: flex;
   gap: 6px;
-  align-items: center;
+  align-items: stretch; /* input + eye toggle share one height */
   width: 100%;
 }
 .lock-pw input {
   flex: 1;
+  min-width: 0;
 }
 .lock-pw .icon-btn {
   flex-shrink: 0;
+}
+/* Accent submit — arrow only (its "Unlock" / "Enable encryption" meaning rides
+   on title/aria-label) to keep on-screen text minimal. */
+.lock-go {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 34px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  transition:
+    filter 0.12s ease,
+    background 0.12s ease;
+}
+.lock-go:hover {
+  filter: brightness(1.06);
+}
+.lock-go:active {
+  filter: brightness(0.95);
 }
 .lock-card input {
   width: 100%;
@@ -877,33 +914,47 @@ body.sff-locked #formContainer {
   font-size: 12px;
   color: var(--danger);
 }
+/* Touch ID column — a tall accent card that matches the passphrase column's
+   height (align-items: stretch on .lock-methods). */
 .lock-device {
+  flex: 0 0 112px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 8px;
+  padding: 12px 8px;
+  border: none;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter 0.12s ease;
+}
+.lock-device:hover {
+  filter: brightness(1.06);
+}
+.lock-device[hidden] {
+  display: none;
 }
 .lock-device-icon {
   display: inline-flex;
   line-height: 0;
 }
-/* "or use your passphrase" divider between the biometric button and the field */
-.lock-or {
+.lock-device-icon svg {
+  width: 24px;
+  height: 24px;
+}
+/* Vertical "or" between the two method columns. */
+.lock-methods-or {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin: 2px 0;
   font-size: 11px;
   color: var(--text-muted);
 }
-.lock-or::before,
-.lock-or::after {
-  content: "";
-  flex: 1;
-  height: 1px;
-  background: var(--border);
-}
-.lock-or[hidden] {
+.lock-methods-or[hidden] {
   display: none;
 }
 .lock-reset {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -102,28 +102,37 @@
           <h2 id="lockTitle">Vault locked</h2>
           <p id="lockHint" class="lock-hint"></p>
 
-          <button id="lockDeviceBtn" class="btn btn-primary lock-device" type="button" hidden>
-            <span class="lock-device-icon" id="lockDeviceIcon" aria-hidden="true"></span>
-            <span id="lockDeviceLabel">Use biometric unlock</span>
-          </button>
-          <div id="lockOr" class="lock-or" hidden>or use your passphrase</div>
-
-          <div class="lock-pw">
-            <input
-              id="lockPass"
-              type="password"
-              placeholder="Master passphrase"
-              autocomplete="off"
-            />
-            <button
-              id="lockPassToggle"
-              class="icon-btn"
-              type="button"
-              aria-label="Show passphrase"
-            ></button>
+          <div id="lockMethods" class="lock-methods">
+            <button id="lockDeviceBtn" class="lock-device" type="button" hidden>
+              <span class="lock-device-icon" id="lockDeviceIcon" aria-hidden="true"></span>
+              <span id="lockDeviceLabel">Touch ID</span>
+            </button>
+            <div id="lockOr" class="lock-methods-or" hidden><span>or</span></div>
+            <div class="lock-pass-col" id="lockPwRow">
+              <div class="lock-pw">
+                <input
+                  id="lockPass"
+                  type="password"
+                  placeholder="Master passphrase"
+                  autocomplete="off"
+                />
+                <button
+                  id="lockPassToggle"
+                  class="icon-btn lock-pw-toggle"
+                  type="button"
+                  aria-label="Show passphrase"
+                ></button>
+              </div>
+              <button
+                id="lockBtn"
+                class="lock-go"
+                type="button"
+                aria-label="Unlock"
+                title="Unlock"
+              ></button>
+            </div>
           </div>
           <div id="lockError" class="lock-error" hidden></div>
-          <button id="lockBtn" class="btn btn-primary lock-submit">Unlock</button>
           <button id="lockReset" class="lock-reset" type="button" hidden>
             Forgot passphrase? Reset vault
           </button>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -450,25 +450,21 @@ function updateDeviceUnlockButton() {
       toggle.setAttribute("aria-label", toggle.title);
     }
   }
-  // Lock-screen button label follows the OS too ("Use Touch ID" / "Use Windows
-  // Hello"), set here since the static HTML can't know the platform.
+  // Lock-screen button label follows the OS ("Touch ID" / "Windows Hello"), set
+  // here since the static HTML can't know the platform. Kept terse — the icon
+  // already says "biometric".
   const lockDeviceLabel = $("lockDeviceLabel");
-  if (lockDeviceLabel) lockDeviceLabel.textContent = `Use ${noun}`;
-  // Lock screen: when this device has biometric unlock enrolled, make it the
-  // prominent action — show the Touch ID / Windows Hello button on top, an
-  // "or use your passphrase" divider, and demote the passphrase Unlock button
-  // to a secondary style. When it's not enrolled, the passphrase stays primary
-  // and the biometric row is hidden entirely.
+  if (lockDeviceLabel) lockDeviceLabel.textContent = noun;
+  // Side-by-side methods: when biometric unlock is enrolled, the Touch ID column
+  // sits next to the passphrase column with an "or" between them. In setup mode
+  // (nothing enrolled yet) the biometric column and the "or" are hidden and the
+  // passphrase column spans the full width.
   const bioReady = deviceUnlockSupported() && hasDeviceUnlock();
   const lockDeviceBtn = $("lockDeviceBtn");
   const lockOr = $("lockOr");
-  const lockBtn = $("lockBtn");
   const inSetup = $("lockScreen") && $("lockScreen").dataset.mode === "setup";
   if (lockDeviceBtn) lockDeviceBtn.hidden = !bioReady || inSetup;
   if (lockOr) lockOr.hidden = !bioReady || inSetup;
-  // The passphrase submit is primary everywhere except when biometric is the
-  // headline action on the unlock screen.
-  if (lockBtn) lockBtn.classList.toggle("btn-primary", !(bioReady && !inSetup));
 }
 
 // Registers a platform-authenticator credential and wraps the CURRENT
@@ -615,12 +611,23 @@ function showLock(mode) {
   if (!screen) return;
   screen.dataset.mode = mode;
 
-  $("lockTitle").textContent = mode === "setup" ? "Encrypt your vault" : "Vault locked";
-  $("lockHint").textContent =
-    mode === "setup"
-      ? "Set a master passphrase to encrypt all credentials and 2FA keys. If you forget it, the data can't be recovered."
-      : "Enter your master passphrase to unlock.";
-  $("lockBtn").textContent = mode === "setup" ? "Enable encryption" : "Unlock";
+  $("lockTitle").textContent = mode === "setup" ? "Encrypt vault" : "Vault locked";
+  const hint = $("lockHint");
+  if (hint) {
+    hint.textContent =
+      mode === "setup" ? "Set a passphrase. If you forget it, the data can't be recovered." : "";
+    hint.hidden = !hint.textContent; // no filler line on the unlock screen
+  }
+  // The submit is a compact arrow button inside the passphrase row; its meaning
+  // ("Unlock" vs "Enable encryption") rides on the title/aria-label, not visible
+  // text, so the row stays single-line. The heading + hint carry the wording.
+  const lockBtn = $("lockBtn");
+  if (lockBtn) {
+    const submitLabel = mode === "setup" ? "Enable encryption" : "Unlock";
+    lockBtn.setAttribute("aria-label", submitLabel);
+    lockBtn.title = submitLabel;
+    setIcon(lockBtn, "arrow-right");
+  }
   // The reset escape hatch only appears after a failed unlock (revealed in the
   // unlock-error path) — not on every lock screen.
   if ($("lockReset")) $("lockReset").hidden = true;
@@ -820,6 +827,7 @@ const ICONS = {
   fingerprint:
     '<path d="M12 11a3 3 0 0 0-3 3c0 2 1 3 1 5"/><path d="M18 11a6 6 0 0 0-9.33-5"/><path d="M6 14a6 6 0 0 0 1 5"/><path d="M9 14a3 3 0 0 1 6 0c0 3-2 4-2 6"/><path d="M3 11a9 9 0 0 1 15.6-6.1"/><path d="M21 11a9 9 0 0 1-2.2 6.1"/>',
   more: '<circle cx="12" cy="5" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="12" cy="19" r="1.6"/>',
+  "arrow-right": '<line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/>',
 };
 
 // Return SVG markup for an icon. `fill` makes a solid glyph (used for pins).


### PR DESCRIPTION
## Summary
Redesigns the lock / encryption-setup screen so the two unlock methods sit **side by side** with minimal text.

- **Touch ID column | "or" | passphrase column** — both stretched to equal height.
- When biometric unlock isn't enrolled (or in setup mode), the Touch ID column and "or" are hidden and the passphrase column spans full width.
- **Less text:** arrow-only accent submit (meaning on `title`/`aria-label`), device button reads just "Touch ID", unlock screen drops its hint line.

## Changes
- `popup.html` — `.lock-methods` row: `#lockDeviceBtn` (Touch ID column), `#lockOr` separator, `.lock-pass-col` (input + eye over the arrow submit).
- `popup.css` — flex columns with `align-items:stretch`; **add missing `[hidden]` overrides** for `.lock-device` / `.lock-methods-or` (their `display:flex` was defeating the `hidden` attribute — a latent bug); widen card to 324px; add `arrow-right` icon.
- `popup.js` — paint arrow + set `aria-label`/`title` per mode; terser device label & hint; bio column + "or" toggle on enrolment/setup.

## Testing
- `npm test` → 70/70; `eslint` + `prettier --check` clean.
- Rendered both states (unlock with Touch ID; setup passphrase-only) and verified the side-by-side layout, alignment, and equal column heights.

Independent of #9 (login-autofill) — branched from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)