### PR TITLE
UX quick wins: labeled Add button + empty-state CTA

### DIFF
--- a/popup/popup.css
+++ b/popup/popup.css
@@ -179,6 +179,19 @@ body {
   width: 16px;
   height: 16px;
 }
+/* Labeled variant: escapes the fixed 34×34 icon-button box for an icon+text pill. */
+.btn-labeled {
+  width: auto;
+  gap: 6px;
+  padding: 7px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.btn-ico {
+  display: inline-flex;
+  line-height: 0;
+}
 .btn-primary {
   background: var(--accent);
   color: var(--on-accent);
@@ -785,6 +798,9 @@ html[data-theme="dark"] .env-custom {
   font-size: 12px;
   margin: 0;
   line-height: 1.5;
+}
+.empty-cta {
+  margin-top: 16px;
 }
 
 /* ── lock / encryption overlay ── */

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -63,7 +63,15 @@
           <span class="search-icon" id="searchIcon" aria-hidden="true"></span>
           <input id="searchInput" type="search" placeholder="Search orgs" autocomplete="off" />
         </div>
-        <button id="addBtn" class="btn btn-primary" title="Add org" aria-label="Add org"></button>
+        <button
+          id="addBtn"
+          class="btn btn-primary btn-labeled"
+          title="Add org"
+          aria-label="Add org"
+        >
+          <span class="btn-ico" id="addBtnIcon" aria-hidden="true"></span>
+          Add org
+        </button>
         <button
           id="importBtn"
           class="btn"
@@ -90,6 +98,10 @@
         <p class="empty-sub" id="emptySub">
           Add your first Salesforce login, or restore from a backup.
         </p>
+        <button id="emptyAddBtn" class="btn btn-primary btn-labeled empty-cta" type="button">
+          <span class="btn-ico" id="emptyAddIcon" aria-hidden="true"></span>
+          Add org
+        </button>
       </div>
 
       <div id="toast" class="toast" role="status" hidden></div>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -235,7 +235,8 @@ function updateTotpChips() {
 // Paint the fixed toolbar/header icons (theme toggle is set by applyTheme).
 function paintStaticIcons() {
   setIcon($("searchIcon"), "search");
-  setIcon($("addBtn"), "plus");
+  setIcon($("addBtnIcon"), "plus"); // labeled "Add org" — icon lives in a child span
+  setIcon($("emptyAddIcon"), "plus");
   setIcon($("importBtn"), "upload");
   setIcon($("exportBtn"), "download");
   setIcon($("emptyIcon"), "bolt");
@@ -870,6 +871,8 @@ function wireToolbar() {
 
   const addBtn = $("addBtn");
   if (addBtn) addBtn.addEventListener("click", () => openForm(null));
+  const emptyAddBtn = $("emptyAddBtn");
+  if (emptyAddBtn) emptyAddBtn.addEventListener("click", () => openForm(null));
 
   const exportBtn = $("exportBtn");
   if (exportBtn) exportBtn.addEventListener("click", exportBackup);


### PR DESCRIPTION
Two low-risk UX improvements from the design review.

- **Labeled "Add org" button** — the toolbar's primary action was a bare `+` icon (tooltip-only). Now icon + text via a new `.btn-labeled` variant. Search still flexes; fits at 360px.
- **Empty-state CTA** — the "No saved orgs yet" screen now has an actual "Add org" button, not just descriptive text.

Focus-reveal for hover-copy icons was already covered (`.cred-copy:focus-within`), so no change needed there.

## Testing
- `npm test` → 70/70; eslint + prettier clean.
- Rendered toolbar + empty state at 360px and verified fit/appearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)